### PR TITLE
Add page options to `PageUpdate`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ cabal.sandbox.config
 cabal.project.local
 .HTF/
 *.json
+uow-apis.cabal

--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ An existing Sitebuilder page can be edited ([API docs](https://warwick.ac.uk/ser
 update :: PageUpdate
 update = PageUpdate {
     puContents = "<html><body>Test</body></html>",
-    puChangeNote = "Test change"
+    puOptions = defaultPageOpts { poEditComment = Just "change notes" }
 }
 
 -- replace the contents of the page at /fac/sci/dcs/test with data from `update`

--- a/src/Warwick/Sitebuilder.hs
+++ b/src/Warwick/Sitebuilder.hs
@@ -80,8 +80,8 @@ editPageFromFile :: Text -> Text -> FilePath -> Warwick ()
 editPageFromFile page comment fp = do 
     contents <- liftIO $ readFile fp
     editPage page API.PageUpdate{
-        puContents = pack contents,
-        puChangeNote = comment
+        puContents = Just $ pack contents,
+        puOptions = API.defaultPageOpts { API.poEditComment = Just comment }
     }
 
 -- | 'pageInfo' @path@ retrieves information about the page at @path@.

--- a/src/Warwick/Sitebuilder/PageUpdate.hs
+++ b/src/Warwick/Sitebuilder/PageUpdate.hs
@@ -66,7 +66,22 @@ optsToXML PageOptions{..} = catMaybes [
 -- | 'defaultPageOpts' represents the default value for PageOptions (all fields
 --   are Nothing)
 defaultPageOpts :: PageOptions
-defaultPageOpts = PageOptions Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing
+defaultPageOpts = PageOptions{
+    poSearchable = Nothing,
+    poVisible = Nothing,
+    poSpanRHS = Nothing,
+    poDeleted = Nothing,
+    poDescription = Nothing,
+    poKeywords = Nothing,
+    poLinkCaption = Nothing,
+    poPageHeading = Nothing,
+    poTitleBarCaption = Nothing,
+    poPageOrder = Nothing,
+    poCommentable = Nothing,
+    poCommentsVisibleToCommentersOnly = Nothing,
+    poLayout = Nothing,
+    poEditComment = Nothing
+}
 
 data PageUpdate = PageUpdate {
     puContents :: Maybe Text,

--- a/src/Warwick/Sitebuilder/PageUpdate.hs
+++ b/src/Warwick/Sitebuilder/PageUpdate.hs
@@ -9,7 +9,7 @@ module Warwick.Sitebuilder.PageUpdate where
 
 import Data.Maybe (catMaybes)
 import Data.List (intersperse)
-import Data.Text (Text)
+import Data.Text (Text, pack)
 import Data.XML.Types 
 
 import Text.Atom.Feed
@@ -39,26 +39,21 @@ data PageOptions = PageOptions {
     poEditComment :: Maybe Text
 } deriving Show
 
--- | 'boolToLowerText' @bool@ converts @bool@ to lowercase text
-boolToLowerText :: Bool -> Text
-boolToLowerText True  = "true"
-boolToLowerText False = "false"
-
 -- | 'optsToXML' @opts@ converts @opts@ to an array of XML elements
 optsToXML :: PageOptions -> [Data.XML.Types.Element]
 optsToXML PageOptions{..} = catMaybes [
-        xmlTextContent "sitebuilder:searchable" <$> (TextString . boolToLowerText <$> poSearchable),
-        xmlTextContent "sitebuilder:visibility" <$> (TextString . boolToLowerText <$> poVisible),
-        xmlTextContent "sitebuilder:span-rhs" <$> (TextString . boolToLowerText <$> poSpanRHS),
-        xmlTextContent "sitebuilder:deleted" <$> (TextString . boolToLowerText <$> poDeleted),
+        xmlTextContent "sitebuilder:searchable" <$> (TextString . pack . show <$> poSearchable),
+        xmlTextContent "sitebuilder:visibility" <$> (TextString . pack . show <$> poVisible),
+        xmlTextContent "sitebuilder:span-rhs" <$> (TextString . pack . show <$> poSpanRHS),
+        xmlTextContent "sitebuilder:deleted" <$> (TextString . pack . show <$> poDeleted),
         xmlTextContent "sitebuilder:description" <$> (TextString <$> poDescription),
         xmlTextContent "sitebuilder:keywords" <$> (TextString . mconcat . intersperse ", " <$> poKeywords),
         xmlTextContent "sitebuilder:link-caption" <$> (TextString <$> poLinkCaption),
         xmlTextContent "sitebuilder:page-heading" <$> (TextString <$> poPageHeading),
         xmlTextContent "sitebuilder:title-bar-caption" <$> (TextString <$> poTitleBarCaption),
         xmlTextContent "sitebuilder:page-order" <$> (TextString <$> poPageOrder),
-        xmlTextContent "sitebuilder:commentable" <$> (TextString . boolToLowerText <$> poCommentable),
-        xmlTextContent "sitebuilder:comments-visible-to-commenters-only" <$> (TextString . boolToLowerText <$> poCommentsVisibleToCommentersOnly),
+        xmlTextContent "sitebuilder:commentable" <$> (TextString . pack . show <$> poCommentable),
+        xmlTextContent "sitebuilder:comments-visible-to-commenters-only" <$> (TextString . pack . show <$> poCommentsVisibleToCommentersOnly),
         xmlTextContent "sitebuilder:layout" <$> (TextString <$> poLayout),
         xmlTextContent "sitebuilder:edit-comment" <$> (TextString <$> poEditComment)
     ]

--- a/src/Warwick/Sitebuilder/PageUpdate.hs
+++ b/src/Warwick/Sitebuilder/PageUpdate.hs
@@ -42,20 +42,34 @@ data PageOptions = PageOptions {
 -- | 'optsToXML' @opts@ converts @opts@ to an array of XML elements
 optsToXML :: PageOptions -> [Data.XML.Types.Element]
 optsToXML PageOptions{..} = catMaybes [
-        xmlTextContent "sitebuilder:searchable" <$> (TextString . pack . show <$> poSearchable),
-        xmlTextContent "sitebuilder:visibility" <$> (TextString . pack . show <$> poVisible),
-        xmlTextContent "sitebuilder:span-rhs" <$> (TextString . pack . show <$> poSpanRHS),
-        xmlTextContent "sitebuilder:deleted" <$> (TextString . pack . show <$> poDeleted),
-        xmlTextContent "sitebuilder:description" <$> (TextString <$> poDescription),
-        xmlTextContent "sitebuilder:keywords" <$> (TextString . mconcat . intersperse ", " <$> poKeywords),
-        xmlTextContent "sitebuilder:link-caption" <$> (TextString <$> poLinkCaption),
-        xmlTextContent "sitebuilder:page-heading" <$> (TextString <$> poPageHeading),
-        xmlTextContent "sitebuilder:title-bar-caption" <$> (TextString <$> poTitleBarCaption),
-        xmlTextContent "sitebuilder:page-order" <$> (TextString <$> poPageOrder),
-        xmlTextContent "sitebuilder:commentable" <$> (TextString . pack . show <$> poCommentable),
-        xmlTextContent "sitebuilder:comments-visible-to-commenters-only" <$> (TextString . pack . show <$> poCommentsVisibleToCommentersOnly),
-        xmlTextContent "sitebuilder:layout" <$> (TextString <$> poLayout),
-        xmlTextContent "sitebuilder:edit-comment" <$> (TextString <$> poEditComment)
+        xmlTextContent "sitebuilder:searchable" <$> 
+            (TextString . pack . show <$> poSearchable),
+        xmlTextContent "sitebuilder:visibility" <$> 
+            (TextString . pack . show <$> poVisible),
+        xmlTextContent "sitebuilder:span-rhs" <$> 
+            (TextString . pack . show <$> poSpanRHS),
+        xmlTextContent "sitebuilder:deleted" <$> 
+            (TextString . pack . show <$> poDeleted),
+        xmlTextContent "sitebuilder:description" <$> 
+            (TextString <$> poDescription),
+        xmlTextContent "sitebuilder:keywords" <$> 
+            (TextString . mconcat . intersperse ", " <$> poKeywords),
+        xmlTextContent "sitebuilder:link-caption" <$> 
+            (TextString <$> poLinkCaption),
+        xmlTextContent "sitebuilder:page-heading" <$> 
+            (TextString <$> poPageHeading),
+        xmlTextContent "sitebuilder:title-bar-caption" <$> 
+            (TextString <$> poTitleBarCaption),
+        xmlTextContent "sitebuilder:page-order" <$> 
+            (TextString <$> poPageOrder),
+        xmlTextContent "sitebuilder:commentable" <$> 
+            (TextString . pack . show <$> poCommentable),
+        xmlTextContent "sitebuilder:comments-visible-to-commenters-only" <$> 
+            (TextString . pack . show <$> poCommentsVisibleToCommentersOnly),
+        xmlTextContent "sitebuilder:layout" <$> 
+            (TextString <$> poLayout),
+        xmlTextContent "sitebuilder:edit-comment" <$> 
+            (TextString <$> poEditComment)
     ]
 
 -- | 'defaultPageOpts' represents the default value for PageOptions (all fields

--- a/src/Warwick/Sitebuilder/PageUpdate.hs
+++ b/src/Warwick/Sitebuilder/PageUpdate.hs
@@ -39,10 +39,12 @@ data PageOptions = PageOptions {
     poEditComment :: Maybe Text
 } deriving Show
 
+-- | 'boolToLowerText' @bool@ converts @bool@ to lowercase text
 boolToLowerText :: Bool -> Text
 boolToLowerText True  = "true"
 boolToLowerText False = "false"
 
+-- | 'optsToXML' @opts@ converts @opts@ to an array of XML elements
 optsToXML :: PageOptions -> [Data.XML.Types.Element]
 optsToXML PageOptions{..} = catMaybes [
         xmlTextContent "sitebuilder:searchable" <$> (TextString . boolToLowerText <$> poSearchable),
@@ -61,6 +63,8 @@ optsToXML PageOptions{..} = catMaybes [
         xmlTextContent "sitebuilder:edit-comment" <$> (TextString <$> poEditComment)
     ]
 
+-- | 'defaultPageOpts' represents the default value for PageOptions (all fields
+--   are Nothing)
 defaultPageOpts :: PageOptions
 defaultPageOpts = PageOptions Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing
 

--- a/src/Warwick/Sitebuilder/PageUpdate.hs
+++ b/src/Warwick/Sitebuilder/PageUpdate.hs
@@ -61,6 +61,9 @@ optsToXML PageOptions{..} = catMaybes [
         xmlTextContent "sitebuilder:edit-comment" <$> (TextString <$> poEditComment)
     ]
 
+defaultPageOpts :: PageOptions
+defaultPageOpts = PageOptions Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing
+
 data PageUpdate = PageUpdate {
     puContents :: Maybe Text,
     puOptions :: PageOptions

--- a/src/Warwick/Sitebuilder/PageUpdate.hs
+++ b/src/Warwick/Sitebuilder/PageUpdate.hs
@@ -7,7 +7,9 @@ module Warwick.Sitebuilder.PageUpdate where
 
 --------------------------------------------------------------------------------
 
-import Data.Text
+import Data.Maybe (catMaybes)
+import Data.List (intersperse)
+import Data.Text (Text)
 import Data.XML.Types 
 
 import Text.Atom.Feed
@@ -20,9 +22,48 @@ import Warwick.Sitebuilder.Atom
 
 --------------------------------------------------------------------------------
 
+data PageOptions = PageOptions {
+    poSearchable :: Maybe Bool,
+    poVisible :: Maybe Bool,
+    poSpanRHS :: Maybe Bool,
+    poDeleted :: Maybe Bool,
+    poDescription :: Maybe Text,
+    poKeywords :: Maybe [Text],
+    poLinkCaption :: Maybe Text,
+    poPageHeading :: Maybe Text,
+    poTitleBarCaption :: Maybe Text,
+    poPageOrder :: Maybe Text,
+    poCommentable :: Maybe Bool,
+    poCommentsVisibleToCommentersOnly :: Maybe Bool,
+    poLayout :: Maybe Text,
+    poEditComment :: Maybe Text
+} deriving Show
+
+boolToLowerText :: Bool -> Text
+boolToLowerText True  = "true"
+boolToLowerText False = "false"
+
+optsToXML :: PageOptions -> [Data.XML.Types.Element]
+optsToXML PageOptions{..} = catMaybes [
+        xmlTextContent "sitebuilder:searchable" <$> (TextString . boolToLowerText <$> poSearchable),
+        xmlTextContent "sitebuilder:visibility" <$> (TextString . boolToLowerText <$> poVisible),
+        xmlTextContent "sitebuilder:span-rhs" <$> (TextString . boolToLowerText <$> poSpanRHS),
+        xmlTextContent "sitebuilder:deleted" <$> (TextString . boolToLowerText <$> poDeleted),
+        xmlTextContent "sitebuilder:description" <$> (TextString <$> poDescription),
+        xmlTextContent "sitebuilder:keywords" <$> (TextString . mconcat . intersperse ", " <$> poKeywords),
+        xmlTextContent "sitebuilder:link-caption" <$> (TextString <$> poLinkCaption),
+        xmlTextContent "sitebuilder:page-heading" <$> (TextString <$> poPageHeading),
+        xmlTextContent "sitebuilder:title-bar-caption" <$> (TextString <$> poTitleBarCaption),
+        xmlTextContent "sitebuilder:page-order" <$> (TextString <$> poPageOrder),
+        xmlTextContent "sitebuilder:commentable" <$> (TextString . boolToLowerText <$> poCommentable),
+        xmlTextContent "sitebuilder:comments-visible-to-commenters-only" <$> (TextString . boolToLowerText <$> poCommentsVisibleToCommentersOnly),
+        xmlTextContent "sitebuilder:layout" <$> (TextString <$> poLayout),
+        xmlTextContent "sitebuilder:edit-comment" <$> (TextString <$> poEditComment)
+    ]
+
 data PageUpdate = PageUpdate {
-    puContents :: Text,
-    puChangeNote :: Text
+    puContents :: Maybe Text,
+    puOptions :: PageOptions
 } deriving Show
 
 instance MimeRender ATOM PageUpdate where 
@@ -31,15 +72,13 @@ instance MimeRender ATOM PageUpdate where
         elementToDoc $ 
         xmlEntry $ 
         (nullEntry "" (TextString "") "") {
-            entryContent = Just $ HTMLContent puContents,
+            entryContent = HTMLContent <$> puContents,
             entryAttrs = [
                 ("xmlns:sitebuilder", [
                     ContentText "http://go.warwick.ac.uk/elab-schemas/atom"
                 ])
             ],
-            entryOther = [
-                xmlTextContent "sitebuilder:edit-comment" (TextString puChangeNote)
-            ]
+            entryOther = optsToXML puOptions
         } 
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
Changes `PageUpdate` to include a `PageOptions` type which allows changes to the page options to be specified. The field `puContent` is also made optional so `Warwick.Sitebuilder.API.editPage` can be used to just edit options without changing content. 

These changes also make it much easier to implement mark as deleted and create page functions