### PR TITLE
Add sitebuilder-util and tabula-client as uow-util

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -49,3 +49,28 @@ jobs:
       run: |
         export PATH=$HOME/.local/bin:$PATH
         stack --stack-yaml=${{ matrix.resolver }}.yaml --no-terminal build --flag uow-apis:build-exe --fast
+        stack --stack-yaml=${{ matrix.resolver }}.yaml --no-terminal install --flag uow-apis:build-exe --fast --local-bin-path=${{ github.workspace }}/bin
+
+    - name: Create release 
+      id: create_release
+      uses: actions/create-release@v1
+      if: ${{ matrix.resolver == 'stack' && github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: latest
+        release_name: Release ${{ github.sha }}
+        draft: false
+        prerelease: false
+
+    - name: Upload release asset
+      id: upload_release_asset 
+      uses: actions/upload-release-asset@v1
+      if: ${{ matrix.resolver == 'stack' && github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }} 
+        asset_path: ${{ github.workspace }}/bin/uow-util
+        asset_name: uow-util
+        asset_content_type: application/octet-stream

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -43,9 +43,9 @@ jobs:
     - name: Install dependencies
       run: |
         export PATH=$HOME/.local/bin:$PATH
-        stack --stack-yaml=${{ matrix.resolver }}.yaml --no-terminal build --only-dependencies --fast
+        stack --stack-yaml=${{ matrix.resolver }}.yaml --no-terminal build --flag uow-apis:build-exe --only-dependencies --fast
         
     - name: Build 
       run: |
         export PATH=$HOME/.local/bin:$PATH
-        stack --stack-yaml=${{ matrix.resolver }}.yaml --no-terminal build --fast
+        stack --stack-yaml=${{ matrix.resolver }}.yaml --no-terminal build --flag uow-apis:build-exe --fast

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -1,6 +1,10 @@
 name: Haskell CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
 
 jobs:
   build:

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ cabal.project.local
 .HTF/
 *.json
 uow-apis.cabal
+.ghci

--- a/app/CmdArgs.hs
+++ b/app/CmdArgs.hs
@@ -19,6 +19,7 @@ import Data.Text
 import Options.Applicative
 
 import Warwick.Tabula.Types
+import Warwick.Tabula.MemberSearchFilter (CourseType)
 
 --------------------------------------------------------------------------------
 
@@ -64,6 +65,12 @@ data TabulaOpts
     | Tutees {
         tabulaOptsAcademicYear :: Text
     }
+    | Enrolments {
+        tabulaOptsAcademicYear :: Text,
+        tabulaOptsDepartments :: [Text],
+        tabulaOptsYearGroup :: [Int],
+        tabulaOptsCourseGroups :: [CourseType]
+    }
     deriving (Eq, Show) 
 
 mc :: ReadM ModuleCode
@@ -86,10 +93,18 @@ tuteesP :: Parser TabulaOpts
 tuteesP = Tutees
     <$> strOption (long "year" <> help "The academic year")
 
+enrolmentsP :: Parser TabulaOpts
+enrolmentsP = Enrolments
+    <$> strOption (long "academic-year" <> help "The academic year")
+    <*> some (strOption (long "department" <> help "Departments to filter by"))
+    <*> many (option auto (long "year" <> help "Year groups to filter by"))
+    <*> many (option auto (long "course-type" <> help "Course types to filter by"))
+
 tabulaP :: Parser Command
 tabulaP = fmap TabulaCmd $ subparser $
     command "download" (info downloadSubmissionsP (progDesc "Download coursework submissions."))
  <> command "tutees" (info tuteesP (progDesc "View information about tutees"))
+ <> command "enrolments" (info enrolmentsP (progDesc "View enrolment information"))
 
 --------------------------------------------------------------------------------
 

--- a/app/CmdArgs.hs
+++ b/app/CmdArgs.hs
@@ -1,0 +1,73 @@
+-------------------------------------------------------------------------------
+-- Haskell bindings for the University of Warwick APIs                       --
+-------------------------------------------------------------------------------
+-- This source code is licensed under the MIT licence found in the           --
+-- LICENSE file in the root directory of this source tree.                   --
+-------------------------------------------------------------------------------
+
+module CmdArgs (
+    SitebuilderOpts(..),
+    Command(..),
+    parseCmdLineArgs
+) where 
+
+--------------------------------------------------------------------------------
+
+import Data.Text 
+
+import Options.Applicative
+
+--------------------------------------------------------------------------------
+
+data SitebuilderOpts 
+    = EditPage {
+        cPage :: Text,
+        cFile :: FilePath,
+        cComment :: Maybe Text
+    }
+    | UploadFile {
+        cPage :: Text,
+        cFile :: FilePath,
+        cSlug :: Maybe Text
+    }
+
+editPageP :: Parser SitebuilderOpts 
+editPageP = EditPage  
+    <$> strOption (long "page" <> metavar "PAGE")
+    <*> strOption (long "file" <> metavar "FILE")
+    <*> optional (strOption (long "comment"))
+
+uploadFileP :: Parser SitebuilderOpts 
+uploadFileP = UploadFile 
+    <$> strOption (long "page" <> metavar "PAGE")
+    <*> strOption (long "file" <> metavar "FILE")
+    <*> optional (strOption (long "name"))
+
+sitebuilderP :: Parser Command 
+sitebuilderP = fmap SitebuilderCmd $ subparser $
+    command "edit" (info editPageP (progDesc "Edit a file.")) <> 
+    command "upload" (info uploadFileP (progDesc "Upload a file."))
+
+--------------------------------------------------------------------------------
+
+-- data TabulaOpts 
+
+--------------------------------------------------------------------------------
+
+data Command 
+    = SitebuilderCmd SitebuilderOpts 
+    -- | TabulaCmd TabulaOpts
+
+commandP :: Parser Command 
+commandP = subparser $ 
+    command "sitebuilder" (info sitebuilderP (progDesc "Sitebuilder commands"))
+
+opts :: ParserInfo Command 
+opts = info (commandP <**> helper) idm
+
+-- | 'parseCmdLineArgs' is a computation which parses the command-line
+-- arguments into a 'Command' value.
+parseCmdLineArgs :: IO Command 
+parseCmdLineArgs = execParser opts
+
+-------------------------------------------------------------------------------

--- a/app/CmdArgs.hs
+++ b/app/CmdArgs.hs
@@ -7,6 +7,7 @@
 
 module CmdArgs (
     SitebuilderOpts(..),
+    TabulaOpts(..),
     Command(..),
     parseCmdLineArgs
 ) where 
@@ -16,6 +17,8 @@ module CmdArgs (
 import Data.Text 
 
 import Options.Applicative
+
+import Warwick.Tabula.Types
 
 --------------------------------------------------------------------------------
 
@@ -30,6 +33,7 @@ data SitebuilderOpts
         cFile :: FilePath,
         cSlug :: Maybe Text
     }
+    deriving (Eq, Show)
 
 editPageP :: Parser SitebuilderOpts 
 editPageP = EditPage  
@@ -50,17 +54,54 @@ sitebuilderP = fmap SitebuilderCmd $ subparser $
 
 --------------------------------------------------------------------------------
 
--- data TabulaOpts 
+data TabulaOpts
+    = DownloadSubmissions {
+        tabulaOptsModuleCode :: ModuleCode,
+        tabulaOptsAcademicYear :: Text,
+        tabulaOptsUnpack :: Bool,
+        tabulaOptsOnlyPDF :: Bool
+    }
+    | Tutees {
+        tabulaOptsAcademicYear :: Text
+    }
+    deriving (Eq, Show) 
+
+mc :: ReadM ModuleCode
+mc = ModuleCode . pack <$> str
+
+downloadSubmissionsP :: Parser TabulaOpts
+downloadSubmissionsP = DownloadSubmissions 
+    <$> argument mc ( metavar "MODULE" <> 
+                      help "The module code (e.g. cs141)"
+                    )
+    <*> strOption (long "year" <> help "The academic year")
+    <*> switch ( long "unpack" <> 
+                 help "Unpack submissions automatically."
+               )
+    <*> switch ( long "only-pdf" <> 
+                 help "Only download PDFs"
+               )
+
+tuteesP :: Parser TabulaOpts
+tuteesP = Tutees
+    <$> strOption (long "year" <> help "The academic year")
+
+tabulaP :: Parser Command
+tabulaP = fmap TabulaCmd $ subparser $
+    command "download" (info downloadSubmissionsP (progDesc "Download coursework submissions."))
+ <> command "tutees" (info tuteesP (progDesc "View information about tutees"))
 
 --------------------------------------------------------------------------------
 
 data Command 
     = SitebuilderCmd SitebuilderOpts 
-    -- | TabulaCmd TabulaOpts
+    | TabulaCmd TabulaOpts
+    deriving (Eq, Show)
 
 commandP :: Parser Command 
 commandP = subparser $ 
     command "sitebuilder" (info sitebuilderP (progDesc "Sitebuilder commands"))
+ <> command "tabula" (info tabulaP (progDesc "Tabula commands"))
 
 opts :: ParserInfo Command 
 opts = info (commandP <**> helper) idm

--- a/app/Config.hs
+++ b/app/Config.hs
@@ -1,0 +1,49 @@
+-------------------------------------------------------------------------------
+-- Haskell bindings for the University of Warwick APIs                       --
+-------------------------------------------------------------------------------
+-- This source code is licensed under the MIT licence found in the           --
+-- LICENSE file in the root directory of this source tree.                   --
+-------------------------------------------------------------------------------
+
+module Config (
+    loadConfig,
+
+    module Warwick.Config
+) where 
+
+-------------------------------------------------------------------------------
+
+import Data.Maybe
+import Data.Text
+
+import System.Directory
+import System.Environment
+
+import Warwick.Config
+
+-------------------------------------------------------------------------------
+
+-- | 'loadConfig' is a computation which tries to load the 
+loadConfig :: IO APIConfig 
+loadConfig = do 
+    exists <- doesFileExist "warwick.json"
+
+    -- first, try to load the configuration from disk 
+    mCfg <- if exists then readAPIConfig "warwick.json"
+            else pure Nothing
+
+    case mCfg of 
+        -- success: return the configuration loaded from disk 
+        Just cfg -> pure cfg 
+        -- failure: try to read the configuration from environment
+        -- variables instead
+        Nothing -> do 
+            username <- fromMaybe "" <$> lookupEnv "UOW_USER"
+            password <- fromMaybe "" <$> lookupEnv "UOW_PASSWORD"
+
+            pure APIConfig{
+                apiUsername = pack username,
+                apiPassword = pack password
+            }
+
+-------------------------------------------------------------------------------

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -12,6 +12,7 @@ module Main ( main ) where
 import CmdArgs
 import Config
 import Sitebuilder
+import Tabula
 
 -------------------------------------------------------------------------------
 
@@ -24,5 +25,6 @@ main = do
 
     case args of 
         SitebuilderCmd opts -> sitebuilderMain cfg opts
+        TabulaCmd opts -> tabulaMain cfg opts
 
 -------------------------------------------------------------------------------

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -10,6 +10,7 @@ module Main ( main ) where
 --------------------------------------------------------------------------------
 
 import CmdArgs
+import Config
 import Sitebuilder
 
 -------------------------------------------------------------------------------
@@ -19,7 +20,9 @@ main :: IO ()
 main = do
     args <- parseCmdLineArgs
 
+    cfg <- loadConfig
+
     case args of 
-        SitebuilderCmd opts -> sitebuilderMain opts
+        SitebuilderCmd opts -> sitebuilderMain cfg opts
 
 -------------------------------------------------------------------------------

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,0 +1,25 @@
+-------------------------------------------------------------------------------
+-- Haskell bindings for the University of Warwick APIs                       --
+-------------------------------------------------------------------------------
+-- This source code is licensed under the MIT licence found in the           --
+-- LICENSE file in the root directory of this source tree.                   --
+-------------------------------------------------------------------------------
+
+module Main ( main ) where 
+
+--------------------------------------------------------------------------------
+
+import CmdArgs
+import Sitebuilder
+
+-------------------------------------------------------------------------------
+
+-- | 'main' is the main entry point for this application.
+main :: IO ()
+main = do
+    args <- parseCmdLineArgs
+
+    case args of 
+        SitebuilderCmd opts -> sitebuilderMain opts
+
+-------------------------------------------------------------------------------

--- a/app/Sitebuilder.hs
+++ b/app/Sitebuilder.hs
@@ -1,0 +1,56 @@
+-------------------------------------------------------------------------------
+-- Haskell bindings for the University of Warwick APIs                       --
+-------------------------------------------------------------------------------
+-- This source code is licensed under the MIT licence found in the           --
+-- LICENSE file in the root directory of this source tree.                   --
+-------------------------------------------------------------------------------
+
+module Sitebuilder ( sitebuilderMain ) where 
+
+-------------------------------------------------------------------------------
+
+import Data.Maybe
+import Data.Text
+
+import System.Environment
+import System.Exit
+import System.IO
+
+import Warwick.Config
+import Warwick.Common
+import Warwick.Sitebuilder
+
+import CmdArgs 
+
+-------------------------------------------------------------------------------
+
+handleAPI :: Show e => IO (Either e a) -> IO a
+handleAPI m = m >>= \case 
+    Left err -> do 
+        hPutStrLn stderr (show err)
+        exitWith (ExitFailure (-1)) 
+    Right _ -> exitSuccess
+
+sitebuilderMain :: SitebuilderOpts -> IO ()
+sitebuilderMain opts = do 
+    username <- fromMaybe "" <$> lookupEnv "SB_USER"
+    password <- fromMaybe "" <$> lookupEnv "SB_PASSWORD"
+
+    let config = APIConfig {
+        apiUsername = pack username,
+        apiPassword = pack password
+    }
+
+    case opts of 
+        EditPage{..} -> do 
+            let comment = fromMaybe "" cComment
+
+            handleAPI $ withAPI Live config $ 
+                editPageFromFile cPage comment cFile
+        UploadFile{..} -> do 
+            let name = fromMaybe "" cSlug
+
+            handleAPI $ withAPI Live config $ 
+                uploadFile cPage name cFile
+
+-------------------------------------------------------------------------------

--- a/app/Sitebuilder.hs
+++ b/app/Sitebuilder.hs
@@ -10,9 +10,7 @@ module Sitebuilder ( sitebuilderMain ) where
 -------------------------------------------------------------------------------
 
 import Data.Maybe
-import Data.Text
 
-import System.Environment
 import System.Exit
 import System.IO
 
@@ -31,15 +29,8 @@ handleAPI m = m >>= \case
         exitWith (ExitFailure (-1)) 
     Right _ -> exitSuccess
 
-sitebuilderMain :: SitebuilderOpts -> IO ()
-sitebuilderMain opts = do 
-    username <- fromMaybe "" <$> lookupEnv "SB_USER"
-    password <- fromMaybe "" <$> lookupEnv "SB_PASSWORD"
-
-    let config = APIConfig {
-        apiUsername = pack username,
-        apiPassword = pack password
-    }
+sitebuilderMain :: APIConfig -> SitebuilderOpts -> IO ()
+sitebuilderMain config opts = do 
 
     case opts of 
         EditPage{..} -> do 

--- a/app/Tabula.hs
+++ b/app/Tabula.hs
@@ -1,0 +1,241 @@
+-------------------------------------------------------------------------------
+-- Haskell bindings for the University of Warwick APIs                       --
+-------------------------------------------------------------------------------
+-- This source code is licensed under the MIT licence found in the           --
+-- LICENSE file in the root directory of this source tree.                   --
+-------------------------------------------------------------------------------
+
+module Tabula ( tabulaMain ) where
+
+-------------------------------------------------------------------------------
+
+import Control.Monad 
+import Control.Monad.Extra
+import Control.Monad.IO.Class
+
+import qualified Data.ByteString as BS (length)
+import qualified Data.HashMap.Lazy as HM
+import Data.Maybe
+import Data.Text (pack, unpack)
+
+import System.Console.AsciiProgress
+import System.Directory
+import System.FilePath
+import System.IO
+
+import Text.Read (readMaybe)
+
+import Warwick.Tabula
+import Warwick.Tabula.Attachment
+import Warwick.Tabula.Member
+import Warwick.Tabula.StudentAssignment
+
+import CmdArgs 
+
+--------------------------------------------------------------------------------
+
+-- untar :: FilePath -> FilePath -> IO ()
+-- untar zf dir = S.shelly $ S.silently $ S.errExit False $ do
+--     r <- S.run "tar" ["-xf", T.pack zf, "-C", T.pack dir]
+--     e <- S.lastExitCode
+--     d <- S.lastStderr
+
+--     S.liftIO $ do
+--         if e == 0 then do
+--             --setSGR [SetColor Foreground Dull Green]
+--             putStr "Unpacked."
+--             --setSGR [Reset]
+--         else do
+--             --setSGR [SetColor Foreground Vivid Red]
+--             putStr $ "Unpack failed (" ++ show e ++ ")."
+--             --setSGR [Reset]
+
+-- unzip :: FilePath -> FilePath -> IO ()
+-- unzip zf dir = S.shelly $ S.silently $ S.errExit False $ do
+--     r <- S.run "unzip" [T.pack zf, "-d", T.pack dir]
+--     e <- S.lastExitCode
+--     d <- S.lastStderr
+
+--     S.liftIO $ do
+--         if e == 0 then do
+--             --setSGR [SetColor Foreground Dull Green]
+--             putStr "Unzipped."
+--             --setSGR [Reset]
+--         else do
+--             --setSGR [SetColor Foreground Vivid Red]
+--             putStr $ "Unzip failed (" ++ show e ++ ")."
+--             --setSGR [Reset]
+
+unpackSubmission :: FilePath -> FilePath -> IO ()
+unpackSubmission _ file = do
+    case takeExtension file of
+            ".zip" -> do
+                --putStr $ "Unzipping " ++ file ++ "... "
+                -- unzip file dir
+                pure ()
+            ".gz" -> do
+                --putStr $ "Unpacking " ++ file ++ "... "
+                -- untar file dir
+                pure ()
+            _ -> putStr $ "Unpack not supported."
+
+--------------------------------------------------------------------------------
+
+-- | Pretty-prints an assignment for the assignment selection menu.
+ppAssignment :: (Assignment, Int) -> IO ()
+ppAssignment (Assignment {..}, idx) = do
+    putStr (show idx)
+    putStr ". "
+    putStr assignmentName
+    when assignmentArchived $ putStr " (Archived)"
+    putStr " - "
+    putStr (show assignmentSubmissions)
+    putStrLn " submission(s)"
+
+-- | Prompts the user to select a coursework within the range.
+promptID :: Int -> IO Int
+promptID len = do
+    putStr "Select coursework [0.."
+    putStr (show $ len-1)
+    putStr "]: "
+
+    r <- readMaybe <$> getLine
+
+    case r of
+        Nothing -> do
+            putStrLn "Not a valid integer."
+            promptID len
+        Just idx | idx >= len -> do
+                    putStrLn "Out of range."
+                    promptID len
+                 | otherwise ->
+                    return idx
+
+-- | Downloads all coursework submissions for an assignment.
+downloadSubmissions :: ModuleCode 
+                    -> Assignment 
+                    -> Bool 
+                    -> Bool 
+                    -> Tabula ()
+downloadSubmissions mc cwk up pdf = do
+    let aid = assignmentID cwk
+        anm = assignmentName cwk
+        dir = "./submissions-" ++ show aid
+
+    -- get a list of all submissions for the assignment
+    TabulaOK{..} <- listSubmissions mc aid
+
+    -- create a directory for the submissions, if there isn't one yet
+    liftIO $ do
+        putStrLn $ "Downloading submissions for " ++ anm ++ "..."
+
+        -- create the directory if it doesn't exist
+        unlessM (doesDirectoryExist dir) $ createDirectory dir
+
+    -- download every submission
+    forM_ (HM.toList tabulaData) $ \(sid, subm) ->
+            case subm of
+                Nothing  -> liftIO $ putStrLn $ sid ++ " has not submitted anything."
+                Just sub -> forM_ (submissionAttachments sub) $ \att -> do
+                    let
+                        subDir = dir </> sid
+                        subFile = subDir </> attachmentFilename att
+                        subExt = takeExtension (attachmentFilename att)
+                    if ((subExt /= ".pdf") && pdf) then do
+                        liftIO $ putStrLn ("Skipping submission for " ++ sid ++ " (" ++ attachmentFilename att ++ " is not a PDF) ... ")
+                    else do
+                        liftIO $ do
+                            putStrLn $ "Downloading submission for " ++ sid ++ " ... "
+                            unlessM (doesDirectoryExist subDir) $ createDirectory subDir
+                        downloadSubmissionWithCallbacks
+                            sid
+                            mc
+                            (assignmentID cwk)
+                            (submissionID sub)
+                            (attachmentFilename att)
+                            subFile
+                            Callbacks {
+                                onWrapper = displayConsoleRegions,
+                                onLength = \l -> newProgressBar def {
+                                                pgTotal = fromIntegral l,
+                                                pgWidth = 100,
+                                                pgOnCompletion = Just "Downloaded."
+                                           },
+                                onUpdate = \pb bs -> tickN pb (BS.length bs),
+                                onComplete = complete
+                            }
+                        liftIO $ do
+                            --putStr "Done. "
+                            when up $ unpackSubmission subDir subFile
+                            --putStrLn ""
+
+selectAssignment :: APIConfig -> ModuleCode -> String -> Bool -> Bool -> IO ()
+selectAssignment cfg mc ay up pdf = do
+    r <- withTabula Live cfg $ do
+        TabulaOK {..} <- listAssignments mc (Just ay)
+
+        case tabulaData of
+            []  -> liftIO $ putStrLn "There are no assignments for this module."
+            [x] -> downloadSubmissions mc x up pdf
+            xs  -> do
+                idx <- liftIO $ do
+                    mapM_ ppAssignment $ zip tabulaData [0..]
+                    promptID (length tabulaData)
+
+                downloadSubmissions mc (xs !! idx) up pdf
+
+    -- handle errors
+    case r of
+        Left err -> putStrLn $ "Communication error:\n" ++ show err
+        Right r -> putStrLn "Program ran successfully."
+
+concernAssignments :: String 
+                   -> [StudentAssignment] 
+                   -> [StudentAssignment]
+concernAssignments ay = 
+    filter $ \StudentAssignment{..} -> case studentAssignmentSubmission of
+        -- if there is no submission, would it be late now?
+        Nothing -> studentAssignmentLate && studentAssignmentAcademicYear == ay
+        -- otherwise, if there is a submission, was the submission late?
+        Just StudentAssignmentSubmission{..} ->
+            studentAssignmentSubmissionLate && studentAssignmentAcademicYear == ay
+
+--------------------------------------------------------------------------------
+
+tabulaMain :: APIConfig -> TabulaOpts -> IO () 
+tabulaMain cfg opts = do 
+    -- disable buffering
+    hSetBuffering stdout NoBuffering
+    hSetBuffering stdin LineBuffering
+
+    case opts of
+        DownloadSubmissions{..} ->
+            selectAssignment cfg 
+                             tabulaOptsModuleCode 
+                             (unpack tabulaOptsAcademicYear)
+                             tabulaOptsUnpack 
+                             tabulaOptsOnlyPDF
+        Tutees{..} -> do
+            let ay = unpack tabulaOptsAcademicYear
+            putStr "User ID: "
+            uid <- getLine
+
+            r <- withTabula Live cfg $ do
+                TabulaOK{..} <- listRelationships uid
+
+                rs <- forM (relationshipsOfType "personalTutor" tabulaData) $ \r -> do
+                    TabulaOK{..} <- retrieveMembers (map (pack . relationshipEntryUniversityID) $ relationshipStudents r) ["member.fullName"]
+
+                    forM (HM.toList tabulaData) $ \(k,v) -> do
+                        liftIO $ putStrLn (fromJust (memberFullName v) ++ "(" ++ unpack k ++ ")")
+                        TabulaAssignmentOK {..} <- personAssignments (unpack k) (Just ay)
+                        let hls = concernAssignments ay $ historicAssignments tabulaAssignmentData
+                            els = concernAssignments ay $ enrolledAssignments tabulaAssignmentData
+
+                        return (memberFullName v, length els, length hls)
+                liftIO $ mapM_ print rs
+                return ()
+
+            print r
+
+-------------------------------------------------------------------------------

--- a/hie.yaml
+++ b/hie.yaml
@@ -1,1 +1,9 @@
-cradle: {stack: { component: "uow-apis" }}
+cradle:
+    stack:
+      - path: "./src"
+        component: "uow-apis:lib"
+      - path: "./app"
+        component: "uow-apis:exe:uow-util"
+
+dependencies:
+  - package.yaml

--- a/package.yaml
+++ b/package.yaml
@@ -74,11 +74,13 @@ executables:
     source-dirs: app
     ghc-options:
     - -Wall
-    - -Werror
     dependencies:
       - uow-apis
+      - extra
       - optparse-applicative
       - filepath
+      - directory
+      - ascii-progress
     default-extensions:
       - LambdaCase
     when:

--- a/package.yaml
+++ b/package.yaml
@@ -18,6 +18,11 @@ synopsis:            Haskell bindings for UoW APIs
 # common to point users to the README.md file.
 description:         Please see the README on GitHub at <https://github.com/mbg/uow-apis#readme>
 
+flags:
+  build-exe:
+    manual: true 
+    default: false
+
 dependencies:
 - base
 - bytestring
@@ -62,3 +67,23 @@ library:
   source-dirs: src
   ghc-options:
   - -Wall
+
+executables:
+  uow-util:
+    main: Main.hs
+    source-dirs: app
+    ghc-options:
+    - -Wall
+    - -Werror
+    dependencies:
+      - uow-apis
+      - optparse-applicative
+      - filepath
+    default-extensions:
+      - LambdaCase
+    when:
+      condition: flag(build-exe)
+      then:
+        buildable: true 
+      else: 
+        buildable: false

--- a/src/Warwick/DownloadSubmission.hs
+++ b/src/Warwick/DownloadSubmission.hs
@@ -87,7 +87,7 @@ downloadSubmissionWithCallbacks :: String
                    -> FilePath
                    -> FilePath
                    -> TabulaDownloadCallbacks a
-                   -> Warwick ()
+                   -> Tabula ()
 downloadSubmissionWithCallbacks sid mc aid subid fn out (Callbacks {..}) = do
     manager            <- getManager
     baseURL            <- getURL

--- a/src/Warwick/Tabula/MemberSearchFilter.hs
+++ b/src/Warwick/Tabula/MemberSearchFilter.hs
@@ -19,6 +19,7 @@ data CourseType
     | PGR
     | Foundation 
     | PreSessional
+    deriving (Eq, Read)
 
 instance Show CourseType where 
     show UG = "UG"

--- a/src/Warwick/Tabula/Types.hs
+++ b/src/Warwick/Tabula/Types.hs
@@ -88,6 +88,7 @@ class FromJSON a => HasPayload a where
     payload v = v .: payloadFieldName (Proxy :: Proxy a)
 
 newtype ObjectList a = ObjectList { getList :: [a] }
+    deriving (Eq, Show)
 
 instance FromJSON a => FromJSON (ObjectList a) where
     parseJSON = withObject "Tabula object array" $ \obj ->
@@ -95,7 +96,8 @@ instance FromJSON a => FromJSON (ObjectList a) where
 
 --------------------------------------------------------------------------------
 
-data UUIDorString = UUID UUID | NotUUID T.Text deriving Show
+data UUIDorString = UUID UUID | NotUUID T.Text 
+    deriving (Eq, Show)
 
 instance FromJSON UUIDorString where
     parseJSON (String v) = case fromText v of
@@ -111,13 +113,13 @@ instance IsString UUID where
 type AcademicYear = String
 
 newtype ModuleCode = ModuleCode { moduleCode :: T.Text }
-    deriving IsString
+    deriving (Eq, Show, IsString)
 
 instance ToHttpApiData ModuleCode where
     toQueryParam (ModuleCode mc) = mc
 
 newtype AssignmentID = AssignmentID { unAssignmentID :: UUID }
-    deriving (IsString)
+    deriving (Eq, IsString)
 
 instance Show AssignmentID where
     show (AssignmentID uuid) = show uuid
@@ -126,6 +128,6 @@ instance FromJSON AssignmentID where
     parseJSON v = AssignmentID <$> parseJSON v
 
 newtype SubmissionID = SubmissionID { unSubmissionID :: UUID }
-    deriving (IsString)
+    deriving (Eq, Show, IsString)
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
This PR will integrate both [`sitebuilder-util`](https://github.com/mbg/sitebuilder-util) and [`tabula-client`](https://github.com/mbg/tabula-client) into one executable named `uow-util` that is part of this package. Both programs are currently just wrappers around certain client functions in `uow-apis` and need to be updated independently of the library. By unifying them in `uow-apis`, they can be updated concurrently with the library. This will render `sitebuilder-util` and `tabula-client` obsolete.

The executable is not built by default and needs to be enabled with e.g. `stack build --flag uow-apis:build-exe`.