### PR TITLE
Add documentation for available page options

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,22 @@ withAPI Live config $ editPage "/fac/sci/dcs/test" update
 withAPI Live config $ editPageFromFile "/fac/sci/dcs/test" "change notes" "./test.html"
 ```
 
+Available page options ([API docs](https://warwick.ac.uk/services/its/servicessupport/web/sitebuilder2/faqs/api/pages-and-files/change-page-properties/)):
+- `poSearchable`: whether the page is visible in search engines
+- `poVisible`: whether the page is visible in the navigation list of its parent page
+- `poSpanRHS`: whether the page should span its right hand side
+- `poDeleted`: whether the page is marked as deleted
+- `poDescription`: the page's description, sometimes shown in Google results and on other Sitebuilder pages
+- `poKeywords`: keywords for a page, used for search and categorisation
+- `poLinkCaption`: the link caption for a page (as used in local navigation)
+- `poPageHeading`: the page heading
+- `poTitleBarCaption`: the title bar caption
+- `poPageOrder`: the page (sort) order for a page, with lower numbers appearing first in local navigation
+- `poCommentable`: whether the page allows comments
+- `poCommentsVisibleToCommentersOnly`: whether comments for a page should only be visible to users who can post comments
+- `poLayout`: the layout of an ID6 page
+- `poEditComment`: the comment to show in the edit history for this edit
+
 Files can be uploaded ([API docs](https://warwick.ac.uk/services/its/servicessupport/web/sitebuilder2/faqs/api/pages-and-files/upload-file)):
 
 ```haskell


### PR DESCRIPTION
Lists every field and gives the description of that field from the ITS docs. I'm not sure if it should list the types or not - maybe a table of field name, type, description would be better?