### PR TITLE
Add rest of sitebuilder endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,18 @@ Files can be uploaded ([API docs](https://warwick.ac.uk/services/its/servicessup
 withAPI Live cfg $ uploadFile "/fac/sci/dcs/test" "README" "./README.md"
 ```
 
+Pages ([API docs](https://warwick.ac.uk/services/its/servicessupport/web/sitebuilder2/faqs/api/pages-and-files/mark-page-deleted/)) can be marked as deleted:
+```haskell
+-- marks the page at /fac/sci/dcs/test as deleted
+withAPI Live cfg $ deletePage "/fac/sci/dcs/test"
+```
+
+Pages ([API docs](https://warwick.ac.uk/services/its/servicessupport/web/sitebuilder2/faqs/api/pages-and-files/mark-page-deleted/)) can be marked as not deleted:
+```haskell
+-- marks the page at /fac/sci/dcs/test as not deleted
+withAPI Live cfg $ restorePage "/fac/sci/dcs/test"
+```
+
 Pages ([API docs](https://warwick.ac.uk/services/its/servicessupport/web/sitebuilder2/faqs/api/pages-and-files/purge-page)) and files ([API docs](https://warwick.ac.uk/services/its/servicessupport/web/sitebuilder2/faqs/api/pages-and-files/purge-file)) can be purged:
 
 ```haskell

--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ withAPI Live config $ createPage "/fac/sci/dcs" opts
 withAPI Live config $ createPageFromFile "/fac/sci/dcs" "Page Title" "testpage" "./test.html"
 ```
 
-- Available page options ([API docs](https://warwick.ac.uk/services/its/servicessupport/web/sitebuilder2/faqs/api/pages-and-files/change-page-properties/)):
+Available page options ([API docs](https://warwick.ac.uk/services/its/servicessupport/web/sitebuilder2/faqs/api/pages-and-files/change-page-properties/)):
    - `poSearchable`: whether the page is visible in search engines
    - `poVisible`: whether the page is visible in the navigation list of its parent page
    - `poSpanRHS`: whether the page should span its right hand side
@@ -355,7 +355,7 @@ opts = defaultFileOpts {
 withAPI Live cfg $ editFileProps "/fac/sci/dcs/test.pdf" opts
 ```
 
-- Available file options ([API docs](https://warwick.ac.uk/services/its/servicessupport/web/sitebuilder2/faqs/api/pages-and-files/change-file-properties/)):
+Available file options ([API docs](https://warwick.ac.uk/services/its/servicessupport/web/sitebuilder2/faqs/api/pages-and-files/change-file-properties/)):
    - `foTitle`: the link caption for the file
    - `foSearchable`: whether the file is visible in search engines 
    - `foVisible`: whether the file is visible in the navigation list of its parent page 

--- a/README.md
+++ b/README.md
@@ -383,4 +383,16 @@ withAPI Live cfg $ purgeFile "/fac/sci/dcs/test.pdf"
 withAPI Live cfg $ uploadFile "/fac/sci/dcs/test" "test.pdf" "/Users/example/test.pdf"
 ```
 
+- Infomation about existing pages can be retrieved ([API docs](https://warwick.ac.uk/services/its/servicessupport/web/sitebuilder2/faqs/api/getting-started)):
+```haskell
+-- retrieves information about page at /fac/sci/dcs
+withAPI Live cfg $ pageInfo "/fac/sci/dcs"
+```
+
+- Information about existing files can be retreived ([API docs](https://warwick.ac.uk/services/its/servicessupport/web/sitebuilder2/faqs/api/getting-started)):
+```haskell
+-- retrieves information about page at /fac/sci/dcs/test.pdf
+withAPI Live cfg $ fileInfo "/fac/sci/dcs/test.pdf"
+```
+
 For details about page/file options see [here](docs/Sitebuilder/Types.md)

--- a/README.md
+++ b/README.md
@@ -320,22 +320,6 @@ withAPI Live config $ createPage "/fac/sci/dcs" opts
 withAPI Live config $ createPageFromFile "/fac/sci/dcs" "Page Title" "testpage" "./test.html"
 ```
 
-Available page options ([API docs](https://warwick.ac.uk/services/its/servicessupport/web/sitebuilder2/faqs/api/pages-and-files/change-page-properties/)):
-   - `poSearchable`: whether the page is visible in search engines
-   - `poVisible`: whether the page is visible in the navigation list of its parent page
-   - `poSpanRHS`: whether the page should span its right hand side
-   - `poDeleted`: whether the page is marked as deleted
-   - `poDescription`: the page's description, sometimes shown in Google results and on other Sitebuilder pages
-   - `poKeywords`: keywords for a page, used for search and categorisation
-   - `poLinkCaption`: the link caption for a page (as used in local navigation)
-   - `poPageHeading`: the page heading
-   - `poTitleBarCaption`: the title bar caption
-   - `poPageOrder`: the page (sort) order for a page, with lower numbers appearing first in local navigation
-   - `poCommentable`: whether the page allows comments
-   - `poCommentsVisibleToCommentersOnly`: whether comments for a page should only be visible to users who can post comments
-   - `poLayout`: the layout of an ID6 page
-   - `poEditComment`: the comment to show in the edit history for this edit
-
 - Files can be uploaded ([API docs](https://warwick.ac.uk/services/its/servicessupport/web/sitebuilder2/faqs/api/pages-and-files/upload-file)):
 
 ```haskell
@@ -354,15 +338,6 @@ opts = defaultFileOpts {
 -- changes /fac/sci/dcs/test.pdf to not be visible in parent navigation and to have link caption "New Caption"
 withAPI Live cfg $ editFileProps "/fac/sci/dcs/test.pdf" opts
 ```
-
-Available file options ([API docs](https://warwick.ac.uk/services/its/servicessupport/web/sitebuilder2/faqs/api/pages-and-files/change-file-properties/)):
-   - `foTitle`: the link caption for the file
-   - `foSearchable`: whether the file is visible in search engines 
-   - `foVisible`: whether the file is visible in the navigation list of its parent page 
-   - `foDeleted`: whether the file is marked as deleted
-   - `foDescription`: the file's description, used for search engines and in other Sitebuilder pages 
-   - `foKeywords`: keywords, used for search optimisation and categorisation 
-   - `foPageOrder`: the order of the file in local navigation 
 
 - Pages ([API docs](https://warwick.ac.uk/services/its/servicessupport/web/sitebuilder2/faqs/api/pages-and-files/mark-page-deleted/)) and files ([API docs](https://warwick.ac.uk/services/its/servicessupport/web/sitebuilder2/faqs/api/pages-and-files/mark-file-deleted/)) can be marked as deleted:
 ```haskell
@@ -398,3 +373,5 @@ withAPI Live cfg $ purge "/fac/sci/dcs/test.pdf"
 -- uploads "/Users/example/test.pdf" to "/fac/sci/dcs/test" as "test.pdf"
 withAPI Live cfg $ uploadFile "/fac/sci/dcs/test" "test.pdf" "/Users/example/test.pdf"
 ```
+
+For details about page/file options see [here](docs/Sitebuilder/Types.md)

--- a/README.md
+++ b/README.md
@@ -303,23 +303,7 @@ withAPI Live config $ editPage "/fac/sci/dcs/test" update
 withAPI Live config $ editPageFromFile "/fac/sci/dcs/test" "change notes" "./test.html"
 ```
 
-- Available page options ([API docs](https://warwick.ac.uk/services/its/servicessupport/web/sitebuilder2/faqs/api/pages-and-files/change-page-properties/)):
-   - `poSearchable`: whether the page is visible in search engines
-   - `poVisible`: whether the page is visible in the navigation list of its parent page
-   - `poSpanRHS`: whether the page should span its right hand side
-   - `poDeleted`: whether the page is marked as deleted
-   - `poDescription`: the page's description, sometimes shown in Google results and on other Sitebuilder pages
-   - `poKeywords`: keywords for a page, used for search and categorisation
-   - `poLinkCaption`: the link caption for a page (as used in local navigation)
-   - `poPageHeading`: the page heading
-   - `poTitleBarCaption`: the title bar caption
-   - `poPageOrder`: the page (sort) order for a page, with lower numbers appearing first in local navigation
-   - `poCommentable`: whether the page allows comments
-   - `poCommentsVisibleToCommentersOnly`: whether comments for a page should only be visible to users who can post comments
-   - `poLayout`: the layout of an ID6 page
-   - `poEditComment`: the comment to show in the edit history for this edit
-
-- Pages can be created ([API docs](https://warwick.ac.uk/services/its/servicessupport/web/sitebuilder2/faqs/api/pages-and-files/create-page/)). As above you can either specificy the contents by hand or load them from a file
+- Pages can be created ([API docs](https://warwick.ac.uk/services/its/servicessupport/web/sitebuilder2/faqs/api/pages-and-files/create-page/)). As above you can either specify the contents by hand or load them from a file
 ```haskell
 opts :: Page
 opts = Page{
@@ -336,6 +320,22 @@ withAPI Live config $ createPage "/fac/sci/dcs" opts
 withAPI Live config $ createPageFromFile "/fac/sci/dcs" "Page Title" "testpage" "./test.html"
 ```
 
+- Available page options ([API docs](https://warwick.ac.uk/services/its/servicessupport/web/sitebuilder2/faqs/api/pages-and-files/change-page-properties/)):
+   - `poSearchable`: whether the page is visible in search engines
+   - `poVisible`: whether the page is visible in the navigation list of its parent page
+   - `poSpanRHS`: whether the page should span its right hand side
+   - `poDeleted`: whether the page is marked as deleted
+   - `poDescription`: the page's description, sometimes shown in Google results and on other Sitebuilder pages
+   - `poKeywords`: keywords for a page, used for search and categorisation
+   - `poLinkCaption`: the link caption for a page (as used in local navigation)
+   - `poPageHeading`: the page heading
+   - `poTitleBarCaption`: the title bar caption
+   - `poPageOrder`: the page (sort) order for a page, with lower numbers appearing first in local navigation
+   - `poCommentable`: whether the page allows comments
+   - `poCommentsVisibleToCommentersOnly`: whether comments for a page should only be visible to users who can post comments
+   - `poLayout`: the layout of an ID6 page
+   - `poEditComment`: the comment to show in the edit history for this edit
+
 - Files can be uploaded ([API docs](https://warwick.ac.uk/services/its/servicessupport/web/sitebuilder2/faqs/api/pages-and-files/upload-file)):
 
 ```haskell
@@ -347,8 +347,8 @@ withAPI Live cfg $ uploadFile "/fac/sci/dcs/test" "README" "./README.md"
 ```haskell
 opts :: FileOptions
 opts = defaultFileOpts {
-   poTitle = Just "New Caption",
-   poVisible = Just False
+   foTitle = Just "New Caption",
+   foVisible = Just False
 }
 
 -- changes /fac/sci/dcs/test.pdf to not be visible in parent navigation and to have link caption "New Caption"
@@ -356,13 +356,13 @@ withAPI Live cfg $ editFileProps "/fac/sci/dcs/test.pdf" opts
 ```
 
 - Available file options ([API docs](https://warwick.ac.uk/services/its/servicessupport/web/sitebuilder2/faqs/api/pages-and-files/change-file-properties/)):
-   - `poTitle`: the link caption for the file
-   - `poSearchable`: whether the file is visible in search engines 
-   - `poVisible`: whether the file is visible in the navigation list of its parent page 
-   - `poDeleted`: whether the file is marked as deleted
-   - `poDescription`: the file's description, used for search engines and in other Sitebuilder pages 
-   - `poKeywords`: keywords, used for search optimisation and categorisation 
-   - `poPageOrder`: the order of the file in local navigation 
+   - `foTitle`: the link caption for the file
+   - `foSearchable`: whether the file is visible in search engines 
+   - `foVisible`: whether the file is visible in the navigation list of its parent page 
+   - `foDeleted`: whether the file is marked as deleted
+   - `foDescription`: the file's description, used for search engines and in other Sitebuilder pages 
+   - `foKeywords`: keywords, used for search optimisation and categorisation 
+   - `foPageOrder`: the order of the file in local navigation 
 
 - Pages ([API docs](https://warwick.ac.uk/services/its/servicessupport/web/sitebuilder2/faqs/api/pages-and-files/mark-page-deleted/)) and files ([API docs](https://warwick.ac.uk/services/its/servicessupport/web/sitebuilder2/faqs/api/pages-and-files/mark-file-deleted/)) can be marked as deleted:
 ```haskell

--- a/README.md
+++ b/README.md
@@ -339,32 +339,41 @@ opts = defaultFileOpts {
 withAPI Live cfg $ editFileProps "/fac/sci/dcs/test.pdf" opts
 ```
 
-- Pages ([API docs](https://warwick.ac.uk/services/its/servicessupport/web/sitebuilder2/faqs/api/pages-and-files/mark-page-deleted/)) and files ([API docs](https://warwick.ac.uk/services/its/servicessupport/web/sitebuilder2/faqs/api/pages-and-files/mark-file-deleted/)) can be marked as deleted:
+- Pages ([API docs](https://warwick.ac.uk/services/its/servicessupport/web/sitebuilder2/faqs/api/pages-and-files/mark-page-deleted/)) can be marked as deleted:
 ```haskell
 -- marks the page at /fac/sci/dcs/test as deleted
-withAPI Live cfg $ delete "/fac/sci/dcs/test"
-
--- marks the file at /fac/sci/dcs/test.pdf as deleted
-withAPI Live cfg $ delete "/fac/sci/dcs/test.pdf"
+withAPI Live cfg $ deletePage "/fac/sci/dcs/test"
 ```
 
-- Pages ([API docs](https://warwick.ac.uk/services/its/servicessupport/web/sitebuilder2/faqs/api/pages-and-files/mark-page-deleted/)) and files ([API docs](https://warwick.ac.uk/services/its/servicessupport/web/sitebuilder2/faqs/api/pages-and-files/mark-file-deleted/)) can be marked as not deleted:
+-  Files ([API docs](https://warwick.ac.uk/services/its/servicessupport/web/sitebuilder2/faqs/api/pages-and-files/mark-file-deleted/)) can be marked as deleted:
+```haskell
+-- marks the file at /fac/sci/dcs/test.pdf as deleted
+withAPI Live cfg $ deleteFile "/fac/sci/dcs/test.pdf"
+```
+
+- Pages ([API docs](https://warwick.ac.uk/services/its/servicessupport/web/sitebuilder2/faqs/api/pages-and-files/mark-page-deleted/)) can be marked as not deleted:
 ```haskell
 -- marks the page at /fac/sci/dcs/test as not deleted
-withAPI Live cfg $ restore "/fac/sci/dcs/test"
-
--- marks the file at /fac/sci/dcs/test.pdf as deleted
-withAPI Live cfg $ restore "/fac/sci/dcs/test.pdf"
+withAPI Live cfg $ restorePage "/fac/sci/dcs/test"
 ```
 
-- Pages ([API docs](https://warwick.ac.uk/services/its/servicessupport/web/sitebuilder2/faqs/api/pages-and-files/purge-page)) and files ([API docs](https://warwick.ac.uk/services/its/servicessupport/web/sitebuilder2/faqs/api/pages-and-files/purge-file)) can be purged:
+- Files ([API docs](https://warwick.ac.uk/services/its/servicessupport/web/sitebuilder2/faqs/api/pages-and-files/mark-file-deleted/)) can be marked as not deleted:
+```haskell
+-- marks the file at /fac/sci/dcs/test.pdf as deleted
+withAPI Live cfg $ restoreFile "/fac/sci/dcs/test.pdf"
+```
+
+- Pages ([API docs](https://warwick.ac.uk/services/its/servicessupport/web/sitebuilder2/faqs/api/pages-and-files/purge-page)) can be purged:
 
 ```haskell
 -- purges the page at /fac/sci/dcs/test 
-withAPI Live cfg $ purge "/fac/sci/dcs/test"
+withAPI Live cfg $ purgePage "/fac/sci/dcs/test"
+```
 
+- Files ([API docs](https://warwick.ac.uk/services/its/servicessupport/web/sitebuilder2/faqs/api/pages-and-files/purge-file)) can be purged
+```haskell
 -- purges the file at /fac/sci/dcs/test.pdf
-withAPI Live cfg $ purge "/fac/sci/dcs/test.pdf"
+withAPI Live cfg $ purgeFile "/fac/sci/dcs/test.pdf"
 ```
 
 - Files can be uploaded ([API docs](https://warwick.ac.uk/services/its/servicessupport/web/sitebuilder2/faqs/api/pages-and-files/upload-file)):

--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ withSSO Live "[API KEY]" $ userSearch defaultSearch{ ssoSearchID = Just "1234567
 
 ## Sitebuilder API
 
-An existing Sitebuilder page can be edited ([API docs](https://warwick.ac.uk/services/its/servicessupport/web/sitebuilder2/faqs/api/pages-and-files/edit-content)). You can either specify the new contents of the file by hand (first example) or load the new contents from a file (second example):
+- An existing Sitebuilder page can be edited ([API docs](https://warwick.ac.uk/services/its/servicessupport/web/sitebuilder2/faqs/api/pages-and-files/edit-content)). You can either specify the new contents of the file by hand (first example) or load the new contents from a file (second example):
 
 ```haskell
 update :: PageUpdate
@@ -303,23 +303,23 @@ withAPI Live config $ editPage "/fac/sci/dcs/test" update
 withAPI Live config $ editPageFromFile "/fac/sci/dcs/test" "change notes" "./test.html"
 ```
 
-Available page options ([API docs](https://warwick.ac.uk/services/its/servicessupport/web/sitebuilder2/faqs/api/pages-and-files/change-page-properties/)):
-- `poSearchable`: whether the page is visible in search engines
-- `poVisible`: whether the page is visible in the navigation list of its parent page
-- `poSpanRHS`: whether the page should span its right hand side
-- `poDeleted`: whether the page is marked as deleted
-- `poDescription`: the page's description, sometimes shown in Google results and on other Sitebuilder pages
-- `poKeywords`: keywords for a page, used for search and categorisation
-- `poLinkCaption`: the link caption for a page (as used in local navigation)
-- `poPageHeading`: the page heading
-- `poTitleBarCaption`: the title bar caption
-- `poPageOrder`: the page (sort) order for a page, with lower numbers appearing first in local navigation
-- `poCommentable`: whether the page allows comments
-- `poCommentsVisibleToCommentersOnly`: whether comments for a page should only be visible to users who can post comments
-- `poLayout`: the layout of an ID6 page
-- `poEditComment`: the comment to show in the edit history for this edit
+- Available page options ([API docs](https://warwick.ac.uk/services/its/servicessupport/web/sitebuilder2/faqs/api/pages-and-files/change-page-properties/)):
+   - `poSearchable`: whether the page is visible in search engines
+   - `poVisible`: whether the page is visible in the navigation list of its parent page
+   - `poSpanRHS`: whether the page should span its right hand side
+   - `poDeleted`: whether the page is marked as deleted
+   - `poDescription`: the page's description, sometimes shown in Google results and on other Sitebuilder pages
+   - `poKeywords`: keywords for a page, used for search and categorisation
+   - `poLinkCaption`: the link caption for a page (as used in local navigation)
+   - `poPageHeading`: the page heading
+   - `poTitleBarCaption`: the title bar caption
+   - `poPageOrder`: the page (sort) order for a page, with lower numbers appearing first in local navigation
+   - `poCommentable`: whether the page allows comments
+   - `poCommentsVisibleToCommentersOnly`: whether comments for a page should only be visible to users who can post comments
+   - `poLayout`: the layout of an ID6 page
+   - `poEditComment`: the comment to show in the edit history for this edit
 
-Pages can be created ([API docs](https://warwick.ac.uk/services/its/servicessupport/web/sitebuilder2/faqs/api/pages-and-files/create-page/)). As above you can either specificy the contents by hand or load them from a file
+- Pages can be created ([API docs](https://warwick.ac.uk/services/its/servicessupport/web/sitebuilder2/faqs/api/pages-and-files/create-page/)). As above you can either specificy the contents by hand or load them from a file
 ```haskell
 opts :: Page
 opts = Page{
@@ -336,33 +336,63 @@ withAPI Live config $ createPage "/fac/sci/dcs" opts
 withAPI Live config $ createPageFromFile "/fac/sci/dcs" "Page Title" "testpage" "./test.html"
 ```
 
-Files can be uploaded ([API docs](https://warwick.ac.uk/services/its/servicessupport/web/sitebuilder2/faqs/api/pages-and-files/upload-file)):
+- Files can be uploaded ([API docs](https://warwick.ac.uk/services/its/servicessupport/web/sitebuilder2/faqs/api/pages-and-files/upload-file)):
 
 ```haskell
 -- uploads the file README.md to the directory at /fac/sci/dcs/test using the name README
 withAPI Live cfg $ uploadFile "/fac/sci/dcs/test" "README" "./README.md"
 ```
 
-Pages ([API docs](https://warwick.ac.uk/services/its/servicessupport/web/sitebuilder2/faqs/api/pages-and-files/mark-page-deleted/)) can be marked as deleted:
+- Properties of existing files can be edited:
+```haskell
+opts :: FileOptions
+opts = defaultFileOpts {
+   poTitle = Just "New Caption",
+   poVisible = Just False
+}
+
+-- changes /fac/sci/dcs/test.pdf to not be visible in parent navigation and to have link caption "New Caption"
+withAPI Live cfg $ editFileProps "/fac/sci/dcs/test.pdf" opts
+```
+
+- Available file options ([API docs](https://warwick.ac.uk/services/its/servicessupport/web/sitebuilder2/faqs/api/pages-and-files/change-file-properties/)):
+   - `poTitle`: the link caption for the file
+   - `poSearchable`: whether the file is visible in search engines 
+   - `poVisible`: whether the file is visible in the navigation list of its parent page 
+   - `poDeleted`: whether the file is marked as deleted
+   - `poDescription`: the file's description, used for search engines and in other Sitebuilder pages 
+   - `poKeywords`: keywords, used for search optimisation and categorisation 
+   - `poPageOrder`: the order of the file in local navigation 
+
+- Pages ([API docs](https://warwick.ac.uk/services/its/servicessupport/web/sitebuilder2/faqs/api/pages-and-files/mark-page-deleted/)) and files ([API docs](https://warwick.ac.uk/services/its/servicessupport/web/sitebuilder2/faqs/api/pages-and-files/mark-file-deleted/)) can be marked as deleted:
 ```haskell
 -- marks the page at /fac/sci/dcs/test as deleted
-withAPI Live cfg $ deletePage "/fac/sci/dcs/test"
+withAPI Live cfg $ delete "/fac/sci/dcs/test"
+
+-- marks the file at /fac/sci/dcs/test.pdf as deleted
+withAPI Live cfg $ delete "/fac/sci/dcs/test.pdf"
 ```
 
-Pages ([API docs](https://warwick.ac.uk/services/its/servicessupport/web/sitebuilder2/faqs/api/pages-and-files/mark-page-deleted/)) can be marked as not deleted:
+- Pages ([API docs](https://warwick.ac.uk/services/its/servicessupport/web/sitebuilder2/faqs/api/pages-and-files/mark-page-deleted/)) and files ([API docs](https://warwick.ac.uk/services/its/servicessupport/web/sitebuilder2/faqs/api/pages-and-files/mark-file-deleted/)) can be marked as not deleted:
 ```haskell
 -- marks the page at /fac/sci/dcs/test as not deleted
-withAPI Live cfg $ restorePage "/fac/sci/dcs/test"
+withAPI Live cfg $ restore "/fac/sci/dcs/test"
+
+-- marks the file at /fac/sci/dcs/test.pdf as deleted
+withAPI Live cfg $ restore "/fac/sci/dcs/test.pdf"
 ```
 
-Pages ([API docs](https://warwick.ac.uk/services/its/servicessupport/web/sitebuilder2/faqs/api/pages-and-files/purge-page)) and files ([API docs](https://warwick.ac.uk/services/its/servicessupport/web/sitebuilder2/faqs/api/pages-and-files/purge-file)) can be purged:
+- Pages ([API docs](https://warwick.ac.uk/services/its/servicessupport/web/sitebuilder2/faqs/api/pages-and-files/purge-page)) and files ([API docs](https://warwick.ac.uk/services/its/servicessupport/web/sitebuilder2/faqs/api/pages-and-files/purge-file)) can be purged:
 
 ```haskell
 -- purges the page at /fac/sci/dcs/test 
 withAPI Live cfg $ purge "/fac/sci/dcs/test"
+
+-- purges the file at /fac/sci/dcs/test.pdf
+withAPI Live cfg $ purge "/fac/sci/dcs/test.pdf"
 ```
 
-Files can be uploaded ([API docs](https://warwick.ac.uk/services/its/servicessupport/web/sitebuilder2/faqs/api/pages-and-files/upload-file)):
+- Files can be uploaded ([API docs](https://warwick.ac.uk/services/its/servicessupport/web/sitebuilder2/faqs/api/pages-and-files/upload-file)):
 
 ```haskell
 -- uploads "/Users/example/test.pdf" to "/fac/sci/dcs/test" as "test.pdf"

--- a/docs/Sitebuilder/Types.md
+++ b/docs/Sitebuilder/Types.md
@@ -1,0 +1,27 @@
+# Types:
+## PageOptions:
+Available page options ([API docs](https://warwick.ac.uk/services/its/servicessupport/web/sitebuilder2/faqs/api/pages-and-files/change-page-properties/)):
+   - `poSearchable`: whether the page is visible in search engines
+   - `poVisible`: whether the page is visible in the navigation list of its parent page
+   - `poSpanRHS`: whether the page should span its right hand side
+   - `poDeleted`: whether the page is marked as deleted
+   - `poDescription`: the page's description, sometimes shown in Google results and on other Sitebuilder pages
+   - `poKeywords`: keywords for a page, used for search and categorisation
+   - `poLinkCaption`: the link caption for a page (as used in local navigation)
+   - `poPageHeading`: the page heading
+   - `poTitleBarCaption`: the title bar caption
+   - `poPageOrder`: the page (sort) order for a page, with lower numbers appearing first in local navigation
+   - `poCommentable`: whether the page allows comments
+   - `poCommentsVisibleToCommentersOnly`: whether comments for a page should only be visible to users who can post comments
+   - `poLayout`: the layout of an ID6 page
+   - `poEditComment`: the comment to show in the edit history for this edit
+
+## FileOptions:
+Available file options ([API docs](https://warwick.ac.uk/services/its/servicessupport/web/sitebuilder2/faqs/api/pages-and-files/change-file-properties/)):
+   - `foTitle`: the link caption for the file
+   - `foSearchable`: whether the file is visible in search engines 
+   - `foVisible`: whether the file is visible in the navigation list of its parent page 
+   - `foDeleted`: whether the file is marked as deleted
+   - `foDescription`: the file's description, used for search engines and in other Sitebuilder pages 
+   - `foKeywords`: keywords, used for search optimisation and categorisation 
+   - `foPageOrder`: the order of the file in local navigation 

--- a/src/Warwick/Sitebuilder.hs
+++ b/src/Warwick/Sitebuilder.hs
@@ -23,7 +23,8 @@ module Warwick.Sitebuilder (
     editFileProps,
     deleteFile,
     restoreFile,
-    purge
+    purgePage,
+    purgeFile
 ) where 
 
 --------------------------------------------------------------------------------
@@ -139,9 +140,9 @@ restorePage = changeDeleteStatus False
 -- | 'editFileProps' @path options@ updates the properties for the file at @path@
 --   with the changes in @options@
 editFileProps :: Text -> API.FileOptions -> Warwick ()
-editFileProps page opts = do
+editFileProps file opts = do
     authData <- getAuthData
-    lift $ lift $ API.editFileProps authData (Just page) (Just "single") opts
+    lift $ lift $ API.editFileProps authData (Just file) (Just "single") opts
 
 -- | 'deletePage' @path@ sets the deleted status to true for the file at @path@
 deleteFile :: Text -> Warwick ()
@@ -151,11 +152,17 @@ deleteFile = flip editFileProps API.defaultFileOpts { API.foDeleted = Just True 
 restoreFile :: Text -> Warwick ()
 restoreFile = flip editFileProps API.defaultFileOpts { API.foDeleted = Just False }
 
--- | 'purge' @path@ purges the page or file located at @path@.
-purge :: Text -> Warwick ()
-purge page = do 
+-- | 'purgePage' @path@ purges the page located at @path@.
+purgePage :: Text -> Warwick ()
+purgePage page = do 
     authData <- getAuthData
-    lift $ lift $ API.purge authData (Just page) (Just "single")
+    lift $ lift $ API.purgePage authData (Just page) (Just "single")
+
+-- | 'purgeFile' @path@ purges the file located at @path@.
+purgeFile :: Text -> Warwick ()
+purgeFile page = do 
+    authData <- getAuthData
+    lift $ lift $ API.purgeFile authData (Just page) (Just "single")
 
 -------------------------------------------------------------------------------
 

--- a/src/Warwick/Sitebuilder.hs
+++ b/src/Warwick/Sitebuilder.hs
@@ -132,18 +132,22 @@ changeDeleteStatus deleted page = do
 deletePage :: Text -> Warwick ()
 deletePage = changeDeleteStatus True
 
--- | 'restorePage' @path@ sets the deleted status to false for the page or file at @path@
+-- | 'restorePage' @path@ sets the deleted status to false for the page at @path@
 restorePage :: Text -> Warwick ()
 restorePage = changeDeleteStatus False
 
+-- | 'editFileProps' @path options@ updates the properties for the file at @path@
+--   with the changes in @options@
 editFileProps :: Text -> API.FileOptions -> Warwick ()
 editFileProps page opts = do
     authData <- getAuthData
     lift $ lift $ API.editFileProps authData (Just page) (Just "single") opts
 
+-- | 'deletePage' @path@ sets the deleted status to true for the file at @path@
 deleteFile :: Text -> Warwick ()
 deleteFile = flip editFileProps API.defaultFileOpts { API.foDeleted = Just True }
 
+-- | 'restorePage' @path@ sets the deleted status to false for the file at @path@
 restoreFile :: Text -> Warwick ()
 restoreFile = flip editFileProps API.defaultFileOpts { API.foDeleted = Just False }
 

--- a/src/Warwick/Sitebuilder.hs
+++ b/src/Warwick/Sitebuilder.hs
@@ -17,6 +17,7 @@ module Warwick.Sitebuilder (
     editPage,
     editPageFromFile,
     pageInfo,
+    fileInfo,
     uploadFile,
     deletePage,
     restorePage,
@@ -52,6 +53,7 @@ import qualified Warwick.Sitebuilder.PageUpdate as API
 import qualified Warwick.Sitebuilder.PageOptions as API
 import qualified Warwick.Sitebuilder.Page as API
 import qualified Warwick.Sitebuilder.FileOptions as API
+import qualified Warwick.Sitebuilder.FileInfo as API
 
 --------------------------------------------------------------------------------
 
@@ -120,6 +122,12 @@ pageInfo :: Text -> Warwick API.PageInfo
 pageInfo page = do 
     authData <- getAuthData
     lift $ lift $ API.pageInfo authData (Just page)
+
+-- | 'fileInfo' @path@ retrieves information about the file at @path@.
+fileInfo :: Text -> Warwick API.FileInfo
+fileInfo page = do 
+    authData <- getAuthData
+    lift $ lift $ API.fileInfo authData (Just page)
 
 -- | 'changeDeleteStatus' @deleted path@ sets the deleted status for the page at 
 --   @path@ to @deleted@

--- a/src/Warwick/Sitebuilder.hs
+++ b/src/Warwick/Sitebuilder.hs
@@ -18,6 +18,8 @@ module Warwick.Sitebuilder (
     editPageFromFile,
     pageInfo,
     uploadFile,
+    deletePage,
+    restorePage,
     purge
 ) where 
 
@@ -113,6 +115,22 @@ pageInfo :: Text -> Warwick API.PageInfo
 pageInfo page = do 
     authData <- getAuthData
     lift $ lift $ API.pageInfo authData (Just page)
+
+-- | 'changeDeleteStatus' @deleted path@ sets the deleted status for the page at 
+--   @path@ to @deleted@
+changeDeleteStatus :: Bool -> Text -> Warwick ()
+changeDeleteStatus deleted page = do
+    authData <- getAuthData
+    lift $ lift $ API.editPage authData (Just page) (Just "single") $ 
+        API.PageUpdate Nothing $ API.defaultPageOpts { API.poDeleted = Just deleted }
+
+-- | 'deletePage' @path@ sets the deleted status to true for the page at @path@
+deletePage :: Text -> Warwick ()
+deletePage = changeDeleteStatus True
+
+-- | 'restorePage' @path@ sets the deleted status to false for the page or file at @path@
+restorePage :: Text -> Warwick ()
+restorePage = changeDeleteStatus False
 
 -- | 'purge' @path@ purges the page or file located at @path@.
 purge :: Text -> Warwick ()

--- a/src/Warwick/Sitebuilder.hs
+++ b/src/Warwick/Sitebuilder.hs
@@ -20,6 +20,9 @@ module Warwick.Sitebuilder (
     uploadFile,
     deletePage,
     restorePage,
+    editFileProps,
+    deleteFile,
+    restoreFile,
     purge
 ) where 
 
@@ -47,6 +50,7 @@ import qualified Warwick.Sitebuilder.PageInfo as API
 import qualified Warwick.Sitebuilder.PageUpdate as API
 import qualified Warwick.Sitebuilder.PageOptions as API
 import qualified Warwick.Sitebuilder.Page as API
+import qualified Warwick.Sitebuilder.FileOptions as API
 
 --------------------------------------------------------------------------------
 
@@ -131,6 +135,17 @@ deletePage = changeDeleteStatus True
 -- | 'restorePage' @path@ sets the deleted status to false for the page or file at @path@
 restorePage :: Text -> Warwick ()
 restorePage = changeDeleteStatus False
+
+editFileProps :: Text -> API.FileOptions -> Warwick ()
+editFileProps page opts = do
+    authData <- getAuthData
+    lift $ lift $ API.editFileProps authData (Just page) (Just "single") opts
+
+deleteFile :: Text -> Warwick ()
+deleteFile = flip editFileProps API.defaultFileOpts { API.foDeleted = Just True }
+
+restoreFile :: Text -> Warwick ()
+restoreFile = flip editFileProps API.defaultFileOpts { API.foDeleted = Just False }
 
 -- | 'purge' @path@ purges the page or file located at @path@.
 purge :: Text -> Warwick ()

--- a/src/Warwick/Sitebuilder/API.hs
+++ b/src/Warwick/Sitebuilder/API.hs
@@ -20,6 +20,7 @@ import Warwick.Sitebuilder.PageInfo
 import Warwick.Sitebuilder.PageUpdate
 import Warwick.Sitebuilder.Page
 import Warwick.Sitebuilder.FileOptions
+import Warwick.Sitebuilder.FileInfo
 
 --------------------------------------------------------------------------------
         
@@ -52,6 +53,11 @@ type SitebuilderAPI =
       QueryParam "page" Text :>
       Get '[JSON] PageInfo
  :<|> SitebuilderAuth :>
+      "api" :>
+      "page.json" :>
+      QueryParam "page" Text :>
+      Get '[JSON] FileInfo
+ :<|> SitebuilderAuth :>
       "edit" :>
       "atom" :>
       "atom.htm" :>
@@ -83,10 +89,11 @@ sitebuilder = Proxy
 editPage :: BasicAuthData -> Maybe Text -> Maybe Text -> PageUpdate -> ClientM ()
 createPage :: BasicAuthData -> Maybe Text -> Page -> ClientM ()
 pageInfo :: BasicAuthData -> Maybe Text -> ClientM PageInfo
+fileInfo :: BasicAuthData -> Maybe Text -> ClientM FileInfo
 purgePage :: BasicAuthData -> Maybe Text -> Maybe Text -> ClientM ()
 editFileProps :: BasicAuthData -> Maybe Text -> Maybe Text -> FileOptions -> ClientM ()
 purgeFile :: BasicAuthData -> Maybe Text -> Maybe Text -> ClientM ()
 
-editPage :<|> createPage :<|> pageInfo :<|> purgePage :<|> editFileProps :<|> purgeFile = client sitebuilder
+editPage :<|> createPage :<|> pageInfo :<|> fileInfo :<|> purgePage :<|> editFileProps :<|> purgeFile = client sitebuilder
 
 --------------------------------------------------------------------------------

--- a/src/Warwick/Sitebuilder/API.hs
+++ b/src/Warwick/Sitebuilder/API.hs
@@ -19,6 +19,7 @@ import Warwick.Sitebuilder.Atom
 import Warwick.Sitebuilder.PageInfo
 import Warwick.Sitebuilder.PageUpdate
 import Warwick.Sitebuilder.Page
+import Warwick.Sitebuilder.FileOptions
 
 --------------------------------------------------------------------------------
         
@@ -63,6 +64,7 @@ type SitebuilderAPI =
       "file.htm" :>
       QueryParam "page" Text :> 
       QueryParam "type" Text :>
+      ReqBody '[ATOM] FileOptions :>
       Put '[ATOM] ()
 
 -- | A proxy value for the 'SitebuilderAPI' type.
@@ -74,9 +76,9 @@ sitebuilder = Proxy
 editPage :: BasicAuthData -> Maybe Text -> Maybe Text -> PageUpdate -> ClientM ()
 createPage :: BasicAuthData -> Maybe Text -> Page -> ClientM ()
 pageInfo :: BasicAuthData -> Maybe Text -> ClientM PageInfo
-editFileProps :: BasicAuthData -> Maybe Text -> Maybe Text -> ClientM ()
+editFileProps :: BasicAuthData -> Maybe Text -> Maybe Text -> FileOptions -> ClientM ()
 purge :: BasicAuthData -> Maybe Text -> Maybe Text -> ClientM ()
 
-editPage :<|> createPage :<|> pageInfo :<|> editFileProps :<|> purge = client sitebuilder
+editPage :<|> createPage :<|> pageInfo :<|> purge :<|> editFileProps = client sitebuilder
 
 --------------------------------------------------------------------------------

--- a/src/Warwick/Sitebuilder/API.hs
+++ b/src/Warwick/Sitebuilder/API.hs
@@ -66,6 +66,13 @@ type SitebuilderAPI =
       QueryParam "type" Text :>
       ReqBody '[ATOM] FileOptions :>
       Put '[ATOM] ()
+ :<|> SitebuilderAuth :>
+      "edit" :>
+      "atom" :>
+      "file.htm" :>
+      QueryParam "page" Text :> 
+      QueryParam "type" Text :>
+      Delete '[ATOM] ()
 
 -- | A proxy value for the 'SitebuilderAPI' type.
 sitebuilder :: Proxy SitebuilderAPI
@@ -76,9 +83,10 @@ sitebuilder = Proxy
 editPage :: BasicAuthData -> Maybe Text -> Maybe Text -> PageUpdate -> ClientM ()
 createPage :: BasicAuthData -> Maybe Text -> Page -> ClientM ()
 pageInfo :: BasicAuthData -> Maybe Text -> ClientM PageInfo
+purgePage :: BasicAuthData -> Maybe Text -> Maybe Text -> ClientM ()
 editFileProps :: BasicAuthData -> Maybe Text -> Maybe Text -> FileOptions -> ClientM ()
-purge :: BasicAuthData -> Maybe Text -> Maybe Text -> ClientM ()
+purgeFile :: BasicAuthData -> Maybe Text -> Maybe Text -> ClientM ()
 
-editPage :<|> createPage :<|> pageInfo :<|> purge :<|> editFileProps = client sitebuilder
+editPage :<|> createPage :<|> pageInfo :<|> purgePage :<|> editFileProps :<|> purgeFile = client sitebuilder
 
 --------------------------------------------------------------------------------

--- a/src/Warwick/Sitebuilder/API.hs
+++ b/src/Warwick/Sitebuilder/API.hs
@@ -57,6 +57,13 @@ type SitebuilderAPI =
       QueryParam "page" Text :> 
       QueryParam "type" Text :>
       Delete '[ATOM] ()
+ :<|> SitebuilderAuth :>
+      "edit" :>
+      "atom" :>
+      "file.htm" :>
+      QueryParam "page" Text :> 
+      QueryParam "type" Text :>
+      Put '[ATOM] ()
 
 -- | A proxy value for the 'SitebuilderAPI' type.
 sitebuilder :: Proxy SitebuilderAPI
@@ -67,8 +74,9 @@ sitebuilder = Proxy
 editPage :: BasicAuthData -> Maybe Text -> Maybe Text -> PageUpdate -> ClientM ()
 createPage :: BasicAuthData -> Maybe Text -> Page -> ClientM ()
 pageInfo :: BasicAuthData -> Maybe Text -> ClientM PageInfo
+editFileProps :: BasicAuthData -> Maybe Text -> Maybe Text -> ClientM ()
 purge :: BasicAuthData -> Maybe Text -> Maybe Text -> ClientM ()
 
-editPage :<|> createPage :<|> pageInfo :<|> purge = client sitebuilder
+editPage :<|> createPage :<|> pageInfo :<|> editFileProps :<|> purge = client sitebuilder
 
 --------------------------------------------------------------------------------

--- a/src/Warwick/Sitebuilder/FileInfo.hs
+++ b/src/Warwick/Sitebuilder/FileInfo.hs
@@ -91,8 +91,8 @@ instance FromJSON FileInfo where
                  <*> obj .: "url"
                  <*> obj .: "contentUpdated"
                  <*> obj .: "deleted"
-                 <*> obj .: "fileSize"
                  <*> obj .: "siteRoot"
+                 <*> obj .: "fileSize"
                  <*> obj .: "updated"
                  <*> obj .: "properties"
 

--- a/src/Warwick/Sitebuilder/FileInfo.hs
+++ b/src/Warwick/Sitebuilder/FileInfo.hs
@@ -1,0 +1,99 @@
+--------------------------------------------------------------------------------
+-- Haskell bindings for the University of Warwick APIs                        --
+-- Copyright 2019-2020 Michael B. Gale (m.gale@warwick.ac.uk)                 --
+--------------------------------------------------------------------------------
+
+module Warwick.Sitebuilder.FileInfo where 
+
+--------------------------------------------------------------------------------
+
+import Data.Aeson
+import Data.Text
+
+import Warwick.Sitebuilder.PageInfo (PageEdit(..))
+
+--------------------------------------------------------------------------------
+
+data FileProperties = FileProperties {
+    fpIncludeLegacyJS :: Bool,
+    fpShowInLocalNavigation :: Bool,
+    fpPageOrder :: Int, 
+    fpAllowSearchEngines :: Bool,
+    fpEscapeHtml :: Bool,
+    fpSupportsPagesToGo :: Bool,
+    fpDeferJS :: Bool
+} deriving Show
+
+instance FromJSON FileProperties where 
+    parseJSON = withObject "FileProperties" $ \obj ->
+        FileProperties <$> obj .: "includeLegacyJavascript"
+                       <*> obj .: "showInLocalNavigation"
+                       <*> obj .: "pageOrder"
+                       <*> obj .: "allowSearchEngines"
+                       <*> obj .: "escapeHtml"
+                       <*> obj .: "supportsPagesToGo"
+                       <*> obj .: "deferJs"
+
+data FileInfo = FileInfo {
+    fileID :: Text,
+    fileParent :: Text,
+    fileName :: Text,
+    fileLinkCaption :: Text, 
+    fileKeywords :: [Text],
+    fileCanEdit :: Bool,
+    fileCanAdmin :: Bool,
+    fileMimeType :: Text,
+    fileEdited :: PageEdit, 
+    filePath :: Text,
+    filePageType :: Text,
+    fileResizeableImage :: Bool, 
+    fileChildren :: [Text],
+    filePubliclyVisible :: Bool,
+    fileContact :: Text,
+    fileImage :: Bool,
+    fileCreator :: Text,
+    fileIsSiteRoot :: Bool,
+    fileCreated :: PageEdit,
+    fileCanContribute :: Bool,
+    filePropertiesUpdated :: PageEdit,
+    fileURL :: Text,
+    fileContentUpdated :: PageEdit,
+    fileDeleted :: Bool,
+    fileSiteRoot :: Text,
+    fileSize :: Int,
+    fileUpdated :: PageEdit,
+    fileProperties :: FileProperties
+} deriving Show
+
+instance FromJSON FileInfo where 
+    parseJSON = withObject "FileInfo" $ \obj ->
+        FileInfo <$> obj .: "id"
+                 <*> obj .: "parent"
+                 <*> obj .: "fileName"
+                 <*> obj .: "linkCaption"
+                 <*> obj .: "keywords"
+                 <*> obj .: "canEdit"
+                 <*> obj .: "canAdmin"
+                 <*> obj .: "mimeType"
+                 <*> obj .: "editedUpdated"
+                 <*> obj .: "path"
+                 <*> obj .: "pageType"
+                 <*> obj .: "resizeableImage"
+                 <*> obj .: "children"
+                 <*> obj .: "publiclyVisible"
+                 <*> obj .: "pageContact"
+                 <*> obj .: "image"
+                 <*> obj .: "creator"
+                 <*> obj .: "isSiteRoot"
+                 <*> obj .: "created"
+                 <*> obj .: "canContribute"
+                 <*> obj .: "propertiesUpdated"
+                 <*> obj .: "url"
+                 <*> obj .: "contentUpdated"
+                 <*> obj .: "deleted"
+                 <*> obj .: "fileSize"
+                 <*> obj .: "siteRoot"
+                 <*> obj .: "updated"
+                 <*> obj .: "properties"
+
+--------------------------------------------------------------------------------

--- a/src/Warwick/Sitebuilder/FileInfo.hs
+++ b/src/Warwick/Sitebuilder/FileInfo.hs
@@ -10,7 +10,7 @@ module Warwick.Sitebuilder.FileInfo where
 import Data.Aeson
 import Data.Text
 
-import Warwick.Sitebuilder.PageInfo (PageEdit(..))
+import Warwick.Sitebuilder.PageEdit
 
 --------------------------------------------------------------------------------
 

--- a/src/Warwick/Sitebuilder/FileOptions.hs
+++ b/src/Warwick/Sitebuilder/FileOptions.hs
@@ -1,0 +1,33 @@
+--------------------------------------------------------------------------------
+-- Haskell bindings for the University of Warwick APIs                        --
+-- Copyright 2019 Michael B. Gale (m.gale@warwick.ac.uk)                      --
+--------------------------------------------------------------------------------
+
+module Warwick.Sitebuilder.FileOptions where 
+
+--------------------------------------------------------------------------------
+
+import Data.Text (Text)
+
+--------------------------------------------------------------------------------
+
+data FileOptions = FileOptions {
+    foTitle :: Maybe Text,
+    foSearchable :: Maybe Bool,
+    foVisible :: Maybe Bool,
+    foDeleted :: Maybe Bool,
+    foDescription :: Maybe Text,
+    foKeywords :: Maybe [Text],
+    foPageOrder :: Maybe Int
+}
+
+defaultFileOpts :: FileOptions
+defaultFileOpts = FileOptions {
+    foTitle = Nothing,
+    foSearchable = Nothing,
+    foVisible = Nothing,
+    foDeleted = Nothing,
+    foDescription = Nothing,
+    foKeywords = Nothing,
+    foPageOrder = Nothing
+}

--- a/src/Warwick/Sitebuilder/FileOptions.hs
+++ b/src/Warwick/Sitebuilder/FileOptions.hs
@@ -18,6 +18,11 @@ import Data.XML.Types
 
 import Text.Atom.Feed
 import Text.Atom.Feed.Export
+import Text.XML (renderLBS, def)
+
+import Servant.API
+
+import Warwick.Sitebuilder.Atom
 
 --------------------------------------------------------------------------------
 
@@ -59,3 +64,17 @@ fileOptsToXML FileOptions{..} = catMaybes [
         xmlTextContent "sitebuilder:page-order" <$> 
             (TextString . pack . show <$> foPageOrder)
     ]
+
+instance MimeRender ATOM FileOptions where
+    mimeRender _ fo = 
+        renderLBS def $ 
+        elementToDoc $ 
+        xmlEntry $ 
+        (nullEntry "" (TextString "") "") {
+            entryAttrs = [
+                ("xmlns:sitebuilder", [
+                    ContentText "http://go.warwick.ac.uk/elab-schemas/atom"
+                ])
+            ],
+            entryOther = fileOptsToXML fo
+        } 

--- a/src/Warwick/Sitebuilder/FileOptions.hs
+++ b/src/Warwick/Sitebuilder/FileOptions.hs
@@ -3,11 +3,21 @@
 -- Copyright 2019 Michael B. Gale (m.gale@warwick.ac.uk)                      --
 --------------------------------------------------------------------------------
 
-module Warwick.Sitebuilder.FileOptions where 
+module Warwick.Sitebuilder.FileOptions (
+    FileOptions(..),
+    defaultFileOpts,
+    fileOptsToXML
+) where 
 
 --------------------------------------------------------------------------------
 
-import Data.Text (Text)
+import Data.Maybe (catMaybes)
+import Data.List (intersperse)
+import Data.Text (Text, pack)
+import Data.XML.Types 
+
+import Text.Atom.Feed
+import Text.Atom.Feed.Export
 
 --------------------------------------------------------------------------------
 
@@ -31,3 +41,21 @@ defaultFileOpts = FileOptions {
     foKeywords = Nothing,
     foPageOrder = Nothing
 }
+
+fileOptsToXML :: FileOptions -> [Element]
+fileOptsToXML FileOptions{..} = catMaybes [
+        xmlTextContent "title" <$>
+            (TextString . pack . show <$> foTitle),
+        xmlTextContent "sitebuilder:searchable" <$> 
+            (TextString . pack . show <$> foSearchable),
+        xmlTextContent "sitebuilder:visibility" <$> 
+            (TextString . pack . show <$> foVisible),
+        xmlTextContent "sitebuilder:deleted" <$> 
+            (TextString . pack . show <$> foDeleted),
+        xmlTextContent "sitebuilder:description" <$> 
+            (TextString <$> foDescription),
+        xmlTextContent "sitebuilder:keywords" <$> 
+            (TextString .  mconcat . intersperse ", " <$> foKeywords),
+        xmlTextContent "sitebuilder:page-order" <$> 
+            (TextString . pack . show <$> foPageOrder)
+    ]

--- a/src/Warwick/Sitebuilder/FileOptions.hs
+++ b/src/Warwick/Sitebuilder/FileOptions.hs
@@ -36,6 +36,8 @@ data FileOptions = FileOptions {
     foPageOrder :: Maybe Int
 }
 
+-- | 'defaultFileOpts' represents the default value for FileOptions (all fields
+--   are Nothing)
 defaultFileOpts :: FileOptions
 defaultFileOpts = FileOptions {
     foTitle = Nothing,
@@ -47,6 +49,7 @@ defaultFileOpts = FileOptions {
     foPageOrder = Nothing
 }
 
+-- | 'fileOptsToXML' @opts@ converts @opts@ to an array of XML elements
 fileOptsToXML :: FileOptions -> [Element]
 fileOptsToXML FileOptions{..} = catMaybes [
         xmlTextContent "title" <$>

--- a/src/Warwick/Sitebuilder/PageEdit.hs
+++ b/src/Warwick/Sitebuilder/PageEdit.hs
@@ -1,0 +1,23 @@
+--------------------------------------------------------------------------------
+-- Haskell bindings for the University of Warwick APIs                        --
+-- Copyright 2019-2020 Michael B. Gale (m.gale@warwick.ac.uk)                 --
+--------------------------------------------------------------------------------
+
+module Warwick.Sitebuilder.PageEdit (PageEdit(..)) where 
+
+--------------------------------------------------------------------------------
+
+import Data.Aeson
+import Data.Text
+
+--------------------------------------------------------------------------------
+
+data PageEdit = PageEdit {
+    peUserName :: Text,
+    peDate :: Int
+} deriving Show
+
+instance FromJSON PageEdit where 
+    parseJSON = withObject "PageEdit" $ \obj ->
+        PageEdit <$> obj .: "user" <*> obj .: "date"
+        

--- a/src/Warwick/Sitebuilder/PageInfo.hs
+++ b/src/Warwick/Sitebuilder/PageInfo.hs
@@ -10,16 +10,9 @@ module Warwick.Sitebuilder.PageInfo where
 import Data.Aeson
 import Data.Text
 
+import Warwick.Sitebuilder.PageEdit
+
 --------------------------------------------------------------------------------
-
-data PageEdit = PageEdit {
-    peUserName :: Text,
-    peDate :: Int
-} deriving Show
-
-instance FromJSON PageEdit where 
-    parseJSON = withObject "PageEdit" $ \obj ->
-        PageEdit <$> obj .: "user" <*> obj .: "date"
 
 data PageProperties = PageProperties {
     ppIncludeLegacyJS :: Bool,


### PR DESCRIPTION
This adds:
- `delete`: Marks page/file as deleted
- `restore`: Marks page/file as not deleted
- `editFileProps`: Edits the properties of a file

It also changes `purge` so it uses the right endpoint when deleting files