### PR TITLE
Add FromHttpApiData instance for TabulaInstance

### DIFF
--- a/src/Warwick/Tabula/Config.hs
+++ b/src/Warwick/Tabula/Config.hs
@@ -14,6 +14,7 @@ module Warwick.Tabula.Config (
 
 import Data.Aeson
 
+import Servant.API
 import Servant.Client
 
 import Warwick.Common
@@ -36,6 +37,12 @@ instance FromJSON TabulaInstance where
     parseJSON (String "dev")     = pure Dev  
     parseJSON val = flip (withObject "TabulaInstance") val $ \obj -> 
         CustomInstance <$> obj .: "custom"
+
+instance FromHttpApiData TabulaInstance where
+    parseQueryParam "live"    = pure Live
+    parseQueryParam "dev"     = pure Dev
+    parseQueryParam "sandbox" = pure Sandbox
+    parseQueryParam url       = Left "Custom tabula instances are not yet supported" -- TODO: Allow parsing custom instances
 
 -- | The URL to the Tabula API.
 liveURL :: BaseUrl

--- a/src/Warwick/Tabula/Config.hs
+++ b/src/Warwick/Tabula/Config.hs
@@ -43,8 +43,8 @@ instance FromHttpApiData TabulaInstance where
     parseQueryParam "live"    = pure Live
     parseQueryParam "dev"     = pure Dev
     parseQueryParam "sandbox" = pure Sandbox
-    parseQueryParam url       = either (Left . pack . show) (pure . CustomInstance) $
-                                    parseBaseUrl $ unpack url
+    parseQueryParam url = either (Left . pack . show) (pure . CustomInstance) $
+        parseBaseUrl $ unpack url
 
 
 -- | The URL to the Tabula API.

--- a/src/Warwick/Tabula/Config.hs
+++ b/src/Warwick/Tabula/Config.hs
@@ -13,6 +13,7 @@ module Warwick.Tabula.Config (
 --------------------------------------------------------------------------------
 
 import Data.Aeson
+import Data.Text
 
 import Servant.API
 import Servant.Client
@@ -42,7 +43,9 @@ instance FromHttpApiData TabulaInstance where
     parseQueryParam "live"    = pure Live
     parseQueryParam "dev"     = pure Dev
     parseQueryParam "sandbox" = pure Sandbox
-    parseQueryParam url       = Left "Custom tabula instances are not yet supported" -- TODO: Allow parsing custom instances
+    parseQueryParam url       = either (Left . pack . show) (pure . CustomInstance) $
+                                    parseBaseUrl $ unpack url
+
 
 -- | The URL to the Tabula API.
 liveURL :: BaseUrl


### PR DESCRIPTION
Required to read `TabulaInstance` as a `QueryParam` in servant. Still needs a method to parse custom instances