### PR TITLE
Member timetable event API

### DIFF
--- a/src/Warwick/Tabula.hs
+++ b/src/Warwick/Tabula.hs
@@ -24,6 +24,7 @@ module Warwick.Tabula (
 
     withTabula,
 
+    -- * Administration & information API
     retrieveModule,
     listRegisteredUsercodes,
     listRegisteredUsercodesIn,
@@ -31,6 +32,7 @@ module Warwick.Tabula (
     retrieveDepartment,
     listDepartmentModules,
 
+    -- * Coursework API
     listAssignments,
     retrieveAssignment,
     listSubmissions,
@@ -40,10 +42,12 @@ module Warwick.Tabula (
     downloadSubmission,
     downloadSubmissionWithCallbacks,
 
+    -- * Small group teaching API
     listSmallGroupSets,
     retrieveSmallGroupAllocations,
     retrieveSmallGroupAttendance,
 
+    -- * Profiles API
     retrieveMember,
     retrieveMembers,
     listRelationships,
@@ -51,6 +55,8 @@ module Warwick.Tabula (
     listMembers,
     retrieveAttendance,
     
+    -- * Timetabling API
+    retrieveMemberEvents,
     retrieveTermDates,
     retrieveTermDatesFor,
     retrieveTermWeeks,
@@ -67,6 +73,7 @@ import Data.Text.Encoding (encodeUtf8)
 import qualified Data.HashMap.Lazy as HM
 import Data.Text (Text, pack)
 import qualified Data.Text as T
+import Data.Time
 
 import Data.List (intercalate)
 
@@ -293,6 +300,20 @@ retrieveAttendance user academicYear = do
     handle $ I.retrieveAttendance authData user (pack academicYear)
 
 -------------------------------------------------------------------------------
+
+-- | 'retrieveMemberEvents' @universityID academicYear startDate endDate@
+-- retrieves a list of 'EventOccurrence' objects for the user identified by
+-- @universityID@. If specified, @academicYear@ restricts the academic year
+-- for which events are retrieved. @startDate@ and @endDate@ can be used to
+-- further narrow down the search range.
+retrieveMemberEvents :: Text
+                     -> Maybe Text 
+                     -> Maybe Day 
+                     -> Maybe Day 
+                     -> Tabula (TabulaResponse [EventOccurrence])
+retrieveMemberEvents user academicYear start end = do 
+    authData <- getAuthData
+    handle $ I.retrieveMemberEvents authData user academicYear start end
 
 -- | `retrieveTermDates` retrieves information about an academic year's terms. 
 -- By default, information for the current academic year is returned, but the 

--- a/src/Warwick/Tabula/API.hs
+++ b/src/Warwick/Tabula/API.hs
@@ -9,11 +9,11 @@ module Warwick.Tabula.API where
 
 import Data.Aeson
 import qualified Data.HashMap.Lazy as HM
-import qualified Data.Map as M
 import Data.ByteString as BS
 import Data.UUID.Types
 import Data.Proxy
 import Data.Text (Text)
+import Data.Time
 
 import Servant.API
 
@@ -219,7 +219,16 @@ type MemberAPI =
 
 -- | Represents the timetabling part of Tabula's API as a type.
 type TimetableAPI =
-      "termdates" :> 
+      TabulaAuth :>
+      "member" :>
+      Capture "userID" Text :>
+      "timetable" :>
+      "events" :>
+      QueryParam "academicYear" Text :>
+      QueryParam "start" Day :>
+      QueryParam "end" Day :>
+      Get '[JSON] (TabulaResponse [EventOccurrence])
+ :<|> "termdates" :> 
       Get '[JSON] (TabulaResponse [Term])
  :<|> "termdates" :> 
       Capture "academicYear" Text :> 

--- a/src/Warwick/Tabula/Internal.hs
+++ b/src/Warwick/Tabula/Internal.hs
@@ -10,6 +10,7 @@ module Warwick.Tabula.Internal where
 import qualified Data.HashMap.Lazy as HM
 import qualified Data.ByteString as BS
 import Data.Text (Text)
+import Data.Time
 
 import Servant.API
 import Servant.Client
@@ -128,6 +129,14 @@ retrieveMember :<|>
 
 --------------------------------------------------------------------------------
 
+retrieveMemberEvents ::
+    BasicAuthData ->
+    Text -> 
+    Maybe Text -> 
+    Maybe Day -> 
+    Maybe Day -> 
+    ClientM (TabulaResponse [EventOccurrence])
+
 retrieveTermDates ::
     ClientM (TabulaResponse [Term])
 
@@ -147,7 +156,8 @@ retrieveTermWeeksFor ::
 retrieveHolidays ::
     ClientM (TabulaResponse [Holiday])
 
-retrieveTermDates :<|>
+retrieveMemberEvents :<|>
+    retrieveTermDates :<|>
     retrieveTermDatesFor :<|>
     retrieveTermWeeks :<|>
     retrieveTermWeeksFor :<|>

--- a/src/Warwick/Tabula/Payload.hs
+++ b/src/Warwick/Tabula/Payload.hs
@@ -1,7 +1,9 @@
---------------------------------------------------------------------------------
--- Haskell bindings for the Tabula API                                        --
--- Copyright 2019 Michael B. Gale (m.gale@warwick.ac.uk)                      --
---------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
+-- Haskell bindings for the University of Warwick APIs                       --
+-------------------------------------------------------------------------------
+-- This source code is licensed under the MIT licence found in the           --
+-- LICENSE file in the root directory of this source tree.                   --
+-------------------------------------------------------------------------------
 
 -- | This module re-exports modules containing payload data types.
 module Warwick.Tabula.Payload (
@@ -13,6 +15,7 @@ module Warwick.Tabula.Payload (
 import Warwick.Tabula.Payload.Attendance as Payload
 import Warwick.Tabula.Payload.CourseDetails as Payload
 import Warwick.Tabula.Payload.Department as Payload
+import Warwick.Tabula.Payload.EventOccurrence as Payload
 import Warwick.Tabula.Payload.Holiday as Payload
 import Warwick.Tabula.Payload.Marks as Payload
 import Warwick.Tabula.Payload.Module as Payload

--- a/src/Warwick/Tabula/Payload/EventOccurrence.hs
+++ b/src/Warwick/Tabula/Payload/EventOccurrence.hs
@@ -1,0 +1,80 @@
+-------------------------------------------------------------------------------
+-- Haskell bindings for the University of Warwick APIs                       --
+-------------------------------------------------------------------------------
+-- This source code is licensed under the MIT licence found in the           --
+-- LICENSE file in the root directory of this source tree.                   --
+-------------------------------------------------------------------------------
+
+module Warwick.Tabula.Payload.EventOccurrence (
+    EventOccurrence(..)
+) where 
+
+-------------------------------------------------------------------------------
+
+import Data.Aeson
+import Data.Text
+import Data.Time
+
+import Warwick.Tabula.Types
+import Warwick.Tabula.Member
+import Warwick.Tabula.Payload.Location
+
+-------------------------------------------------------------------------------
+
+-- | https://warwick.ac.uk/services/its/servicessupport/web/tabula/api/timetabling/event-occurrence-object
+data EventOccurrence = EventOccurrence {
+    -- | A unique identifier for the timetable event. For Syllabus+ events, 
+    -- this is generated from an MD5 hex of the name, start time, end time, 
+    -- day of week, location name and context.
+    occurrenceID :: Text,
+    -- | The name of the timetable event, e.g. CS141L.
+    occurrenceName :: Text,
+    -- | The human-readable of the timetable event. Typically empty for 
+    -- Syallabus+ events.
+    occurrenceTitle :: Text,
+    -- | A description of the timetable event.
+    occurrenceDescription :: Text,
+    -- | The type of event.
+    occurrenceType :: Text,
+    -- | The start time of the event.
+    occurrenceStart :: LocalTime,
+    -- | The end time of the event.
+    occurrenceEnd :: LocalTime,
+    -- | An object representing the location of the event, or 'Nothing' if 
+    -- there isn't one. 
+    occurrenceLocation :: Maybe Location,
+    -- | The context of the timetable event. This is typically the module
+    -- code, e.g. CS141
+    occurrenceContext :: Maybe Text,
+    -- | Any comments for the timetable event, or 'Nothing' if none exist.
+    occurrenceComments :: Maybe Text,
+    -- | A list of University IDs for staff members who are linked to 
+    -- delivering this event.
+    occurrenceStaffUniversityIDs :: [Text],
+    -- | A list of 'Member' objects, with the following properties:
+    -- - firstName
+    -- - lastName
+    -- - email
+    -- - userType
+    occurrenceStaff :: [Member]
+} deriving (Eq, Show)
+
+instance FromJSON EventOccurrence where 
+    parseJSON = withObject "EventOccurrence" $ \obj -> 
+        EventOccurrence <$> obj .: "uid"
+                        <*> obj .: "name"
+                        <*> obj .: "title"
+                        <*> obj .: "description"
+                        <*> obj .: "eventType"
+                        <*> obj .: "start"
+                        <*> obj .: "end"
+                        <*> obj .:? "location"
+                        <*> obj .:? "context"
+                        <*> obj .:? "comments"
+                        <*> obj .: "staffUniversityIds"
+                        <*> obj .: "staff"
+
+instance HasPayload [EventOccurrence] where 
+    payloadFieldName _ = "events"
+
+-------------------------------------------------------------------------------

--- a/src/Warwick/Tabula/Payload/Location.hs
+++ b/src/Warwick/Tabula/Payload/Location.hs
@@ -1,0 +1,32 @@
+-------------------------------------------------------------------------------
+-- Haskell bindings for the University of Warwick APIs                       --
+-------------------------------------------------------------------------------
+-- This source code is licensed under the MIT licence found in the           --
+-- LICENSE file in the root directory of this source tree.                   --
+-------------------------------------------------------------------------------
+
+module Warwick.Tabula.Payload.Location (
+    Location(..)
+) where 
+
+-------------------------------------------------------------------------------
+
+import Data.Aeson
+import Data.Text
+
+-------------------------------------------------------------------------------
+
+-- | Represents campus locations.
+data Location = Location {
+    -- | The name of the location.
+    locationName :: Text,
+    -- | The unique ID of the location.
+    locationId :: Text
+} deriving (Eq, Show)
+
+instance FromJSON Location where 
+    parseJSON = withObject "Location" $ \obj ->
+        Location <$> obj .: "name" 
+                 <*> obj .: "locationId"
+
+-------------------------------------------------------------------------------

--- a/src/Warwick/Tabula/Payload/SmallGroup.hs
+++ b/src/Warwick/Tabula/Payload/SmallGroup.hs
@@ -1,7 +1,9 @@
---------------------------------------------------------------------------------
--- Haskell bindings for the University of Warwick APIs                        --
--- Copyright 2019 Michael B. Gale (m.gale@warwick.ac.uk)                      --
---------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
+-- Haskell bindings for the University of Warwick APIs                       --
+-------------------------------------------------------------------------------
+-- This source code is licensed under the MIT licence found in the           --
+-- LICENSE file in the root directory of this source tree.                   --
+-------------------------------------------------------------------------------
 
 module Warwick.Tabula.Payload.SmallGroup where 
 
@@ -13,9 +15,9 @@ import qualified Data.Map as M
 
 import Warwick.Common
 import Warwick.Tabula.Types
-import Warwick.Tabula.Attachment
 import Warwick.Tabula.Payload.Module
 import Warwick.Tabula.Payload.Note
+import Warwick.Tabula.Payload.Location
 
 --------------------------------------------------------------------------------
     
@@ -77,17 +79,6 @@ data Tutor = Tutor {
 instance FromJSON Tutor where 
     parseJSON = withObject "Tutor" $ \obj ->
         Tutor <$> obj .: "userId" <*> obj .:? "universityId"
-
---------------------------------------------------------------------------------
-
-data Location = Location {
-    lName :: Text,
-    lId :: Maybe Text 
-} deriving (Eq, Show)
-
-instance FromJSON Location where 
-    parseJSON = withObject "Location" $ \obj -> 
-        Location <$> obj .: "name" <*> obj .:? "locationId"
 
 --------------------------------------------------------------------------------
 

--- a/src/Warwick/Tabula/Payload/Term.hs
+++ b/src/Warwick/Tabula/Payload/Term.hs
@@ -1,9 +1,13 @@
---------------------------------------------------------------------------------
--- Haskell bindings for the Tabula API                                        --
--- Copyright 2019 Michael B. Gale (m.gale@warwick.ac.uk)                      --
---------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
+-- Haskell bindings for the University of Warwick APIs                       --
+-------------------------------------------------------------------------------
+-- This source code is licensed under the MIT licence found in the           --
+-- LICENSE file in the root directory of this source tree.                   --
+-------------------------------------------------------------------------------
 
-module Warwick.Tabula.Payload.Term where 
+module Warwick.Tabula.Payload.Term (
+    Term(..)
+) where 
 
 --------------------------------------------------------------------------------
 
@@ -11,27 +15,9 @@ import Data.Aeson
 import Data.Text
 
 import Warwick.Tabula.Types
+import Warwick.Tabula.Payload.WeekRange
 
 --------------------------------------------------------------------------------
-
--- | Represents an object specifying the week number range for a term.
-data WeekRange = WeekRange {
-    -- | The number of the first week in the term.
-    weekRangeMin :: Int,
-    -- | The number of the last week in the term.
-    weekRangeMax :: Int
-} deriving Show
-
-instance ToJSON WeekRange where 
-    toJSON WeekRange{..} =
-        object [ "minWeek" .= weekRangeMin 
-               , "maxWeek" .= weekRangeMax 
-               ]
-
-instance FromJSON WeekRange where 
-    parseJSON = withObject "WeekRange" $ \obj ->
-        WeekRange <$> obj .: "minWeek"
-                  <*> obj .: "maxWeek"
 
 -- | Represents information about an academic term.
 data Term = Term {

--- a/src/Warwick/Tabula/Payload/WeekRange.hs
+++ b/src/Warwick/Tabula/Payload/WeekRange.hs
@@ -1,0 +1,37 @@
+-------------------------------------------------------------------------------
+-- Haskell bindings for the University of Warwick APIs                       --
+-------------------------------------------------------------------------------
+-- This source code is licensed under the MIT licence found in the           --
+-- LICENSE file in the root directory of this source tree.                   --
+-------------------------------------------------------------------------------
+
+module Warwick.Tabula.Payload.WeekRange (
+    WeekRange(..)
+) where 
+
+-------------------------------------------------------------------------------
+
+import Data.Aeson 
+
+-------------------------------------------------------------------------------
+
+-- | Represents an object specifying the week number range for a term.
+data WeekRange = WeekRange {
+    -- | The number of the first week in the term.
+    weekRangeMin :: Int,
+    -- | The number of the last week in the term.
+    weekRangeMax :: Int
+} deriving (Eq, Show)
+
+instance ToJSON WeekRange where 
+    toJSON WeekRange{..} =
+        object [ "minWeek" .= weekRangeMin 
+               , "maxWeek" .= weekRangeMax 
+               ]
+
+instance FromJSON WeekRange where 
+    parseJSON = withObject "WeekRange" $ \obj ->
+        WeekRange <$> obj .: "minWeek"
+                  <*> obj .: "maxWeek"
+
+-------------------------------------------------------------------------------


### PR DESCRIPTION
This adds support for the Tabula API described at https://warwick.ac.uk/services/its/servicessupport/web/tabula/api/timetabling/member-events.

There are some breaking changes:
- the library now uses `LocalTime` instead of `UTCTime` since Tabula mostly returns times in local time, rather than UTC 
- support for older Stack resolvers is dropped since `time >= 1.9` is required now