### PR TITLE
Add sitebuilder "sync" function to uow-util

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ To upload a file, such as an image or a PDF, to SiteBuilder, you can use `uow-ut
 
 - `--name FILENAME` can be used to specify a custom name for the file, different from the name of the file that is being uploaded.
 
+#### Syncing a site
+
+To sync a site from a configuration file, you can run `uow-util sitebuilder sync --config FILE`, where `FILE` is the path to the configuration file. See [here](docs/Sitebuilder/Sync.md) for more information about the configuration
+
 ### Docker
 
 To acquire the latest version of the Docker image, run `docker pull docker.pkg.github.com/mbg/uow-apis/uow-util:latest` (you may need to be authenticated to the GitHub registry). The image can then be run as usual with `docker run --rm docker.pkg.github.com/mbg/uow-apis/uow-util:latest` and options/commands can be specified as if you were running `uow-util` directly. Using this has the advantage that you do not need to compile the binaries yourself if you are on a platform for which we do not provide pre-built executables.

--- a/app/CmdArgs.hs
+++ b/app/CmdArgs.hs
@@ -35,6 +35,9 @@ data SitebuilderOpts
         cFile :: FilePath,
         cSlug :: Maybe Text
     }
+    | SyncSite {
+        cConfigPath :: FilePath
+    }
     deriving (Eq, Show)
 
 editPageP :: Parser SitebuilderOpts 
@@ -49,10 +52,14 @@ uploadFileP = UploadFile
     <*> strOption (long "file" <> metavar "FILE")
     <*> optional (strOption (long "name"))
 
+syncSiteP :: Parser SitebuilderOpts
+syncSiteP = SyncSite <$> strOption (long "config-file" <> metavar "CONFIG_FILE")
+
 sitebuilderP :: Parser Command 
 sitebuilderP = fmap SitebuilderCmd $ subparser $
     command "edit" (info editPageP (progDesc "Edit a file.")) <> 
-    command "upload" (info uploadFileP (progDesc "Upload a file."))
+    command "upload" (info uploadFileP (progDesc "Upload a file.")) <>
+    command "sync" (info syncSiteP (progDesc "Synchronise a site."))
 
 --------------------------------------------------------------------------------
 

--- a/app/CmdArgs.hs
+++ b/app/CmdArgs.hs
@@ -53,7 +53,7 @@ uploadFileP = UploadFile
     <*> optional (strOption (long "name"))
 
 syncSiteP :: Parser SitebuilderOpts
-syncSiteP = SyncSite <$> strOption (long "config-file" <> metavar "CONFIG_FILE")
+syncSiteP = SyncSite <$> strOption (long "config" <> metavar "FILE")
 
 sitebuilderP :: Parser Command 
 sitebuilderP = fmap SitebuilderCmd $ subparser $

--- a/app/Sitebuilder.hs
+++ b/app/Sitebuilder.hs
@@ -15,7 +15,8 @@ import Data.Text as T (Text, snoc, last)
 import Data.Yaml (decodeFileThrow)
 
 import System.Exit
-import System.FilePattern.Directory (FilePattern, getDirectoryFiles) 
+import System.FilePattern (FilePattern)
+import System.FilePattern.Directory (getDirectoryFiles) 
 import System.IO
 
 import Warwick.Config

--- a/app/Sitebuilder.hs
+++ b/app/Sitebuilder.hs
@@ -9,7 +9,10 @@ module Sitebuilder ( sitebuilderMain ) where
 
 -------------------------------------------------------------------------------
 
+import Data.Aeson
 import Data.Maybe
+import Data.Text (Text)
+import Data.Yaml (decodeFileThrow)
 
 import System.Exit
 import System.IO
@@ -17,8 +20,27 @@ import System.IO
 import Warwick.Config
 import Warwick.Common
 import Warwick.Sitebuilder
+import Warwick.Sitebuilder.PageOptions
 
 import CmdArgs 
+
+-------------------------------------------------------------------------------
+
+data PageConfig = PageConfig {
+    scPage :: Text,
+    scContent :: FilePath,
+    scProperties :: PageOptions,
+    scFiles :: FilePath,
+    scChildren :: [PageConfig]
+}
+
+instance FromJSON PageConfig where
+    parseJSON = withObject "PageConfig" $ \v -> 
+        PageConfig <$> v .: "page"
+                   <*> v .: "content"
+                   <*> v .: "properties"
+                   <*> v .: "files"
+                   <*> v .: "children"
 
 -------------------------------------------------------------------------------
 
@@ -28,6 +50,9 @@ handleAPI m = m >>= \case
         hPutStrLn stderr (show err)
         exitWith (ExitFailure (-1)) 
     Right _ -> exitSuccess
+
+processPage :: APIConfig -> PageConfig -> IO ()
+processPage = undefined
 
 sitebuilderMain :: APIConfig -> SitebuilderOpts -> IO ()
 sitebuilderMain config opts = do 
@@ -43,5 +68,9 @@ sitebuilderMain config opts = do
 
             handleAPI $ withAPI Live config $ 
                 uploadFile cPage name cFile
+        SyncSite{..} -> do
+            conf <- decodeFileThrow cConfigPath :: IO [PageConfig]
+
+            mapM_ (processPage config) conf
 
 -------------------------------------------------------------------------------

--- a/app/Sitebuilder.hs
+++ b/app/Sitebuilder.hs
@@ -83,12 +83,11 @@ processPage apiCfg parent PageConfig{..} = do
         -- the properties due to an issue with how sitebuilder handles captions
         -- and creating pages
         Left _ -> do
-            handleAPI $ withAPI Live apiCfg
-                      $ createPage pageParent
-                      $ Page "" contents pageName defaultPageOpts
-            handleAPI $ withAPI Live apiCfg
-                      $ editPage page
-                      $ PageUpdate Nothing pcProperties
+            handleAPI $ withAPI Live apiCfg $ do
+                  createPage pageParent $ 
+                      Page "" contents pageName defaultPageOpts
+                  editPage page $ 
+                      PageUpdate Nothing pcProperties
         -- if the page exists then update the page with given contents and
         -- properties
         Right _ -> handleAPI $ withAPI Live apiCfg
@@ -97,8 +96,7 @@ processPage apiCfg parent PageConfig{..} = do
 
     -- get all files matching the patterns given and upload them
     files <- getDirectoryFiles "." pcFiles
-    forM_ files $ \f -> handleAPI $ withAPI Live apiCfg
-                                  $ uploadFile page (pack f) f
+    handleAPI $ withAPI Live apiCfg $ forM_ files $ \f -> uploadFile page (pack f) f
 
     -- process children
     let newParent = if T.last page == '/' then page else page `snoc` '/'

--- a/app/Sitebuilder.hs
+++ b/app/Sitebuilder.hs
@@ -47,8 +47,8 @@ instance FromJSON PageConfig where
         PageConfig <$> v .: "page"
                    <*> v .: "content"
                    <*> v .: "properties"
-                   <*> v .: "files"
-                   <*> v .: "children"
+                   <*> fmap (fromMaybe []) (v .:? "files")
+                   <*> fmap (fromMaybe []) (v .:? "children")
 
 -------------------------------------------------------------------------------
 

--- a/app/Sitebuilder.hs
+++ b/app/Sitebuilder.hs
@@ -59,16 +59,19 @@ handleAPI m = m >>= \case
         exitWith (ExitFailure (-1)) 
     Right _ -> exitSuccess
 
-processPage :: APIConfig -> PageConfig -> IO ()
-processPage config PageConfig{..} = do   
+processPage :: APIConfig -> Text -> PageConfig -> IO ()
+processPage config prefix PageConfig{..} = do
+    -- TODO: this breaks if prefix doesn't end in /
+    let page = prefix <> pcPage
+
     -- upload page
     -- TODO: need to check if page exists and use create if so
-    handleAPI $ withAPI Live config $ editPageFromFile pcPage "" pcContent
+    handleAPI $ withAPI Live config $ editPageFromFile page "" pcContent
 
     -- upload files
 
     -- process children
-    mapM_ (processPage config) pcChildren
+    mapM_ (processPage config page) pcChildren
 
 sitebuilderMain :: APIConfig -> SitebuilderOpts -> IO ()
 sitebuilderMain config opts = do 
@@ -87,6 +90,6 @@ sitebuilderMain config opts = do
         SyncSite{..} -> do
             pages <- decodeFileThrow cConfigPath :: IO [PageConfig]
 
-            mapM_ (processPage config) pages
+            mapM_ (processPage config "") pages
 
 -------------------------------------------------------------------------------

--- a/app/Sitebuilder.hs
+++ b/app/Sitebuilder.hs
@@ -76,17 +76,19 @@ processPage apiCfg parent PageConfig{..} = do
     
     -- read the contents of the file specified
     contents <- pack <$> readFile pcContent
-    
-    -- if pageHeading is set in the config use this as the title when creating
-    -- pages
-    let pageTitle = fromMaybe "" $ poPageHeading pcProperties
 
     case info of
         -- if the page doesn't exist then create the page with the given content
-        -- and properties
-        Left _ -> handleAPI $ withAPI Live apiCfg
-                            $ createPage pageParent
-                            $ Page pageTitle contents pageName pcProperties
+        -- and properties. This makes a second edit request to the page to set
+        -- the properties due to an issue with how sitebuilder handles captions
+        -- and creating pages
+        Left _ -> do
+            handleAPI $ withAPI Live apiCfg
+                      $ createPage pageParent
+                      $ Page "" contents pageName defaultPageOpts
+            handleAPI $ withAPI Live apiCfg
+                      $ editPage page
+                      $ PageUpdate Nothing pcProperties
         -- if the page exists then update the page with given contents and
         -- properties
         Right _ -> handleAPI $ withAPI Live apiCfg

--- a/app/Sitebuilder.hs
+++ b/app/Sitebuilder.hs
@@ -25,10 +25,10 @@ import Warwick.Config
 import Warwick.Common
 import Warwick.Sitebuilder
 import Warwick.Sitebuilder.Page (Page(..))
-import Warwick.Sitebuilder.PageOptions (PageOptions, defaultPageOpts)
+import Warwick.Sitebuilder.PageOptions (PageOptions(..), defaultPageOpts)
 import Warwick.Sitebuilder.PageUpdate (PageUpdate(..))
 
-import CmdArgs 
+import CmdArgs
 
 -------------------------------------------------------------------------------
 
@@ -75,15 +75,18 @@ processPage apiCfg parent PageConfig{..} = do
             x -> x
     
     -- read the contents of the file specified
-    -- TODO: test this works and now sets properties (and titles work on
-    -- creating pages)
     contents <- pack <$> readFile pcContent
+    
+    -- if pageHeading is set in the config use this as the title when creating
+    -- pages
+    let pageTitle = fromMaybe "" $ poPageHeading pcProperties
+
     case info of
         -- if the page doesn't exist then create the page with the given content
         -- and properties
         Left _ -> handleAPI $ withAPI Live apiCfg
                             $ createPage pageParent
-                            $ Page "" contents pageName pcProperties
+                            $ Page pageTitle contents pageName pcProperties
         -- if the page exists then update the page with given contents and
         -- properties
         Right _ -> handleAPI $ withAPI Live apiCfg

--- a/docs/Sitebuilder/Sync.md
+++ b/docs/Sitebuilder/Sync.md
@@ -1,13 +1,13 @@
 # Sitebuilder Sync Config
 
-The configuration for the sync function consists of a yaml file containing a list of page configurations. If the page doesn't exist it is created, and if it does exist it is updated. Each page consists of the fields:
-- `page`: The path to the page
-- `content`: The path to the file containing the page content
-- `properties`: (optional) A list of properties to set for the page (for a list of all options see [here](Types.md#pageoptions), the name of the property in the config is the name here without the `po` prefix)
-- `files`: (optional) A list of files to upload under the page. File patterns are accepted.
-- `children`: (optional) A list of child pages to this page. These follow the same structure as described here
+The configuration for the sync function consists of a yaml file containing a list of page configurations. If a page doesn't exist it is created, and if it does exist it is updated. Each page configuration consists of the following fields:
+- `page`: The path to the page on SiteBuilder
+- `content`: The path to the file containing the page contents with which the page should be created or updated
+- `properties`: (optional) A list of properties to set for the page (for a list of all options see [here](Types.md#pageoptions), the name of the property in the config here is the name of the option without the `po` prefix)
+- `files`: (optional) A list of files to upload under the page. [File patterns](https://hackage.haskell.org/package/filepattern-0.1.2/docs/System-FilePattern.html#v:-63--61--61-) are accepted
+- `children`: (optional) A list of child pages configurations. These configurations are the same as for top-level page configurations as described here, except the paths are relative to their parent
 
-It is important to note if you are defining subpages not as children then the subpage must come after the parent in the list, otherwise creating the pages will fail.
+It is important to note if you are are configuring sub-pages at the top-level, rather than as children of a given page, then the sub-page configurations must come after the parent in the configuration file, otherwise creating the pages will fail.
 
 ### Example Config
 

--- a/docs/Sitebuilder/Sync.md
+++ b/docs/Sitebuilder/Sync.md
@@ -9,7 +9,7 @@ The configuration for the sync function consists of a yaml file containing a lis
 
 It is important to note if you are defining subpages not as children then the subpage must come after the parent in the list, otherwise creating the pages will fail.
 
-## Example Config
+### Example Config
 
 ```yaml
 - path: /fac/sci/dcs/materials/cs141

--- a/docs/Sitebuilder/Sync.md
+++ b/docs/Sitebuilder/Sync.md
@@ -1,0 +1,37 @@
+# Sitebuilder Sync Config
+
+The configuration for the sync function consists of a yaml file containing a list of page configurations. If the page doesn't exist it is created, and if it does exist it is updated. Each page consists of the fields:
+- `page`: The path to the page
+- `content`: The path to the file containing the page content
+- `properties`: (optional) A list of properties to set for the page (for a list of all options see [here](Types.md#pageoptions), the name of the property in the config is the name here without the `po` prefix)
+- `files`: (optional) A list of files to upload under the page. File patterns are accepted.
+- `children`: (optional) A list of child pages to this page. These follow the same structure as described here
+
+It is important to note if you are defining subpages not as children then the subpage must come after the parent in the list, otherwise creating the pages will fail.
+
+## Example Config
+
+```yaml
+- path: /fac/sci/dcs/materials/cs141
+  content: cs141-material.html
+  properties:
+    spanRHS: true
+    linkCaption: CS141
+    pageHeading: CS141 - Functional Programming
+    titleBarCaption: CS141 - Functional Programming
+  files:
+  - files/*
+  - img/image1.png
+  children:
+    - path: term3/
+      source: term3.html
+      properties:
+        spanRHS: true
+- path: /fac/sci/dcs/materials/cs264
+  content: cs264-material.html
+```
+
+Would create/update 3 pages:
+- `/fac/sci/dcs/materials/cs141` with the content from `cs141-material.html` and with the `spanRHS` property set and the captions set as specified, and upload the file `img/image1.png` and every file under `files/`
+- `/fac/sci/dcs/materials/cs141` with the content from `term3.html` and the `spanRHS` property set
+- `/fac/sci/dcs/materials/cs264` with the content from `cs264-material.html`

--- a/package.yaml
+++ b/package.yaml
@@ -81,6 +81,7 @@ executables:
       - filepath
       - directory
       - ascii-progress
+      - yaml
     default-extensions:
       - LambdaCase
     when:

--- a/package.yaml
+++ b/package.yaml
@@ -82,6 +82,7 @@ executables:
       - directory
       - ascii-progress
       - yaml
+      - filepattern
     default-extensions:
       - LambdaCase
     when:

--- a/src/Warwick/Sitebuilder/PageInfo.hs
+++ b/src/Warwick/Sitebuilder/PageInfo.hs
@@ -45,7 +45,6 @@ data PageInfo = PageInfo {
     pageKeywords :: [Text],
     pageCanEdit :: Bool,
     pageCanAdmin :: Bool,
-    pageDescription :: Text,
     pageShortTitle :: Text, 
     pageMimeType :: Text,
     pageEdited :: PageEdit, 
@@ -77,7 +76,6 @@ instance FromJSON PageInfo where
                  <*> obj .: "keywords"
                  <*> obj .: "canEdit"
                  <*> obj .: "canAdmin"
-                 <*> obj .: "description"
                  <*> obj .: "shortTitle"
                  <*> obj .: "mimeType"
                  <*> obj .: "editedUpdated"

--- a/src/Warwick/Sitebuilder/PageInfo.hs
+++ b/src/Warwick/Sitebuilder/PageInfo.hs
@@ -45,6 +45,7 @@ data PageInfo = PageInfo {
     pageKeywords :: [Text],
     pageCanEdit :: Bool,
     pageCanAdmin :: Bool,
+    pageDescription :: Maybe Text,
     pageShortTitle :: Text, 
     pageMimeType :: Text,
     pageEdited :: PageEdit, 
@@ -76,6 +77,7 @@ instance FromJSON PageInfo where
                  <*> obj .: "keywords"
                  <*> obj .: "canEdit"
                  <*> obj .: "canAdmin"
+                 <*> obj .:? "description"
                  <*> obj .: "shortTitle"
                  <*> obj .: "mimeType"
                  <*> obj .: "editedUpdated"

--- a/src/Warwick/Sitebuilder/PageOptions.hs
+++ b/src/Warwick/Sitebuilder/PageOptions.hs
@@ -11,6 +11,7 @@ module Warwick.Sitebuilder.PageOptions (
 
 --------------------------------------------------------------------------------
 
+import Data.Aeson
 import Data.Maybe (catMaybes)
 import Data.List (intersperse)
 import Data.Text (Text, pack)
@@ -37,6 +38,23 @@ data PageOptions = PageOptions {
     poLayout :: Maybe Text,
     poEditComment :: Maybe Text
 } deriving Show
+
+instance FromJSON PageOptions where
+    parseJSON = withObject "PageOptions" $ \v ->
+        PageOptions <$> v .:? "searchable"
+                    <*> v .:? "visible"
+                    <*> v .:? "spanRHS"
+                    <*> v .:? "deleted"
+                    <*> v .:? "description"
+                    <*> v .:? "keywords"
+                    <*> v .:? "linkCaption"
+                    <*> v .:? "pageHeading"
+                    <*> v .:? "titleBarCaption"
+                    <*> v .:? "pageOrder"
+                    <*> v .:? "commentable"
+                    <*> v .:? "commentsVisibleToCommentersOnly"
+                    <*> v .:? "layout"
+                    <*> v .:? "editComment"
 
 -- | 'optsToXML' @opts@ converts @opts@ to an array of XML elements
 optsToXML :: PageOptions -> [Element]

--- a/src/Warwick/Sitebuilder/PageOptions.hs
+++ b/src/Warwick/Sitebuilder/PageOptions.hs
@@ -37,7 +37,7 @@ data PageOptions = PageOptions {
     poCommentsVisibleToCommentersOnly :: Maybe Bool,
     poLayout :: Maybe Text,
     poEditComment :: Maybe Text
-} deriving Show
+} deriving (Eq, Show)
 
 instance FromJSON PageOptions where
     parseJSON = withObject "PageOptions" $ \v ->


### PR DESCRIPTION
This PR (when complete) adds a new option to `uow-util sitebuilder`, "sync", which takes the path to a configuration file which specifies a list of pages to create/update. For example, with the configuration file:
```yaml
- path: /fac/sci/dcs/materials/cs141
  content: cs141-material.html
  properties:
    spanRHS: true
  files:
  - files/
  - img/image1.png
  children:
    - path: term3/
      source: term3.html
      properties:
        spanRHS: true
- path: /fac/sci/dcs/materials/cs264
  content: cs264-material.html
  properties:
    spanRHS: true
```
This would create or replace the 3 pages:
- `/fac/sci/dcs/materials/cs141` with the contents from the file `cs141-material.html`
- `/fac/sci/dcs/materials/cs141/term3` with the contents from the file `term3.html`
- `/fac/sci/dcs/materials/cs264` with the contents from the file `cs264-material.html`

All with the property "spanRHS" set to true

(Currently this is quite broken, I wouldn't put too much effort into checking the code yet, though opinions on the config are appreciated)