### PR TITLE
Improve CI rules

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -96,6 +96,7 @@ jobs:
         asset_name: uow-util
         tag: ${{ github.ref }}
         overwrite: true
+        release_name: Release ${{ steps.build.outputs.version }}
 
     - name: Build Docker image
       if: ${{ matrix.resolver == 'stack' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -5,8 +5,12 @@ on:
     branches: [master]
     tags:
       - 'v*'
+    paths-ignore:
+      - 'docs/**'
   pull_request:
     branches: [master]
+    paths-ignore:
+      - 'docs/**'
 
 env:
   IMAGE_NAME: uow-util


### PR DESCRIPTION
- Don't run CI when only documentation is updated
- Explicitly set release name for asset upload to (hopefully) avoid duplicate releases