### PR TITLE
Add support for creating/updating pages with RHS content

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,6 +406,7 @@ withSSO Live "[API KEY]" $ userSearch defaultSearch{ ssoSearchID = Just "1234567
 update :: PageUpdate
 update = PageUpdate {
     puContents = "<html><body>Test</body></html>",
+    puRhsContent = Nothing,
     puOptions = defaultPageOpts { poEditComment = Just "change notes" }
 }
 
@@ -422,6 +423,7 @@ opts :: Page
 opts = Page{
     pcTitle = "Page Title",
     pcContents = "<html><body>Test</body></html>",
+    pcRhsContents = Nothing,
     pcPageName = "testpage",
     pcOptions = defaultPageOpts 
 }
@@ -443,7 +445,7 @@ withAPI Live cfg $ uploadFile "/fac/sci/dcs/test" "README" "./README.md"
 - Properties of existing files can be edited:
 ```haskell
 opts :: FileOptions
-opts = defaultFileOpts {
+opts = defaultFileOpts{
    foTitle = Just "New Caption",
    foVisible = Just False
 }

--- a/app/Sitebuilder.hs
+++ b/app/Sitebuilder.hs
@@ -40,6 +40,8 @@ data PageConfig = PageConfig {
     pcPage :: Text,
     -- | The path to the contents for the page
     pcContent :: FilePath,
+    -- | The path of the RHS contents for the page
+    pcRhsContent :: Maybe FilePath,
     -- | The properties for the page
     pcProperties :: PageOptions,
     -- | The files to upload under this page. Note that all files are flattened
@@ -53,6 +55,7 @@ instance FromJSON PageConfig where
     parseJSON = withObject "PageConfig" $ \v -> 
         PageConfig <$> v .: "page"
                    <*> v .: "content"
+                   <*> v .:? "rhsContent"
                    <*> v .:? "properties" .!= defaultPageOpts
                    <*> v .:? "files" .!= []
                    <*> v .:? "children" .!= []
@@ -79,6 +82,11 @@ processPage apiCfg parent PageConfig{..} = do
     -- read the contents of the file specified
     contents <- T.readFile pcContent
 
+    -- read the RHS contents, if specified
+    mRhsContents <- case pcRhsContent of 
+        Nothing -> pure Nothing 
+        Just rhsFile -> Just <$> T.readFile rhsFile
+
     case info of
         -- if the page doesn't exist then create the page with the given content
         -- and properties. This makes a second edit request to the page to set
@@ -89,9 +97,9 @@ processPage apiCfg parent PageConfig{..} = do
 
             handleAPI $ withAPI Live apiCfg $ do
                   createPage pageParent $ 
-                      Page "" contents pageName defaultPageOpts
+                      Page "" contents mRhsContents pageName defaultPageOpts
                   editPage page $ 
-                      PageUpdate Nothing pcProperties
+                      PageUpdate Nothing mRhsContents pcProperties
         -- if the page exists then update the page with given contents and
         -- properties
         Right _ -> do
@@ -99,7 +107,7 @@ processPage apiCfg parent PageConfig{..} = do
             
             handleAPI $ withAPI Live apiCfg
                       $ editPage page
-                      $ PageUpdate (Just contents) pcProperties
+                      $ PageUpdate (Just contents) mRhsContents pcProperties
 
     -- get all files matching the patterns given and upload them
     files <- getDirectoryFiles "." pcFiles

--- a/app/Sitebuilder.hs
+++ b/app/Sitebuilder.hs
@@ -96,11 +96,9 @@ processPage apiCfg parent PageConfig{..} = do
             T.putStrLn $ "Creating page " <> page <> " from " <> pack pcContent
                       <> maybe "" (" and " <>) (pack <$> pcRhsContent)
 
-            handleAPI $ withAPI Live apiCfg $ do
-                  createPage pageParent $ 
-                      Page "" contents mRhsContents pageName defaultPageOpts
-                  editPage page $ 
-                      PageUpdate Nothing mRhsContents pcProperties
+            handleAPI $ withAPI Live apiCfg 
+                      $ createPage pageParent 
+                      $ Page "" contents mRhsContents pageName pcProperties
         -- if the page exists then update the page with given contents and
         -- properties
         Right _ -> do

--- a/app/Sitebuilder.hs
+++ b/app/Sitebuilder.hs
@@ -94,6 +94,7 @@ processPage apiCfg parent PageConfig{..} = do
         -- and creating pages
         Left _ -> do
             T.putStrLn $ "Creating page " <> page <> " from " <> pack pcContent
+                      <> maybe "" (" and " <>) (pack <$> pcRhsContent)
 
             handleAPI $ withAPI Live apiCfg $ do
                   createPage pageParent $ 
@@ -104,6 +105,7 @@ processPage apiCfg parent PageConfig{..} = do
         -- properties
         Right _ -> do
             T.putStrLn $ "Updating page " <> page <> " with " <> pack pcContent
+                      <> maybe "" (" and " <>) (pack <$> pcRhsContent)
             
             handleAPI $ withAPI Live apiCfg
                       $ editPage page

--- a/docs/Sitebuilder/Sync.md
+++ b/docs/Sitebuilder/Sync.md
@@ -3,6 +3,7 @@
 The configuration for the sync function consists of a yaml file containing a list of page configurations. If a page doesn't exist it is created, and if it does exist it is updated. Each page configuration consists of the following fields:
 - `page`: The path to the page on SiteBuilder
 - `content`: The path to the file containing the page contents with which the page should be created or updated
+- `rhsContent`: (optional) The path to the file containing the page content with which the RHS of the page should be created or updated
 - `properties`: (optional) A list of properties to set for the page (for a list of all options see [here](Types.md#pageoptions), the name of the property in the config here is the name of the option without the `po` prefix)
 - `files`: (optional) A list of files to upload under the page. [File patterns](https://hackage.haskell.org/package/filepattern-0.1.2/docs/System-FilePattern.html#v:-63--61--61-) are accepted
 - `children`: (optional) A list of child pages configurations. These configurations are the same as for top-level page configurations as described here, except the paths are relative to their parent
@@ -24,14 +25,15 @@ It is important to note if you are are configuring sub-pages at the top-level, r
   - img/image1.png
   children:
     - page: term3/
-      source: term3.html
+      content: term3.html
+      rhsContent: term3-rhs.html
       properties:
-        spanRHS: true
+        spanRHS: false
 - page: /fac/sci/dcs/materials/cs264
   content: cs264-material.html
 ```
 
 Would create/update 3 pages:
 - `/fac/sci/dcs/materials/cs141` with the content from `cs141-material.html` and with the `spanRHS` property set and the captions set as specified, and upload the file `img/image1.png` and every file under `files/`
-- `/fac/sci/dcs/materials/cs141` with the content from `term3.html` and the `spanRHS` property set
+- `/fac/sci/dcs/materials/cs141` with the content from `term3.html` and the `spanRHS` property set to `false` where the RHS content comes from `term3-rhs.html`
 - `/fac/sci/dcs/materials/cs264` with the content from `cs264-material.html`

--- a/package.yaml
+++ b/package.yaml
@@ -67,6 +67,7 @@ library:
   source-dirs: src
   ghc-options:
   - -Wall
+  - -Werror=missing-fields
 
 executables:
   uow-util:

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                uow-apis
-version:             0.4.0.0
+version:             0.4.1.0
 github:              mbg/uow-apis
 license:             MIT
 author:              Michael B. Gale <m.gale@warwick.ac.uk>, Oscar Harris <Oscar.Harris@warwick.ac.uk>

--- a/package.yaml
+++ b/package.yaml
@@ -26,6 +26,7 @@ flags:
 dependencies:
 - base
 - bytestring
+- data-default
 - text
 - time
 - iso8601-time

--- a/src/Warwick/Sitebuilder.hs
+++ b/src/Warwick/Sitebuilder.hs
@@ -1,7 +1,9 @@
---------------------------------------------------------------------------------
--- Haskell bindings for the University of Warwick APIs                        --
--- Copyright 2019 Michael B. Gale (m.gale@warwick.ac.uk)                      --
---------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
+-- Haskell bindings for the University of Warwick APIs                       --
+-------------------------------------------------------------------------------
+-- This source code is licensed under the MIT licence found in the           --
+-- LICENSE file in the root directory of this source tree.                   --
+-------------------------------------------------------------------------------
 
 {-# LANGUAGE OverloadedStrings #-}
 
@@ -93,9 +95,10 @@ createPage path pageData = do
 createPageFromFile :: Text -> Text -> Text -> FilePath -> Warwick ()
 createPageFromFile path title name fp = do
     contents <- liftIO $ readFile fp
-    createPage path $ API.Page {
+    createPage path $ API.Page{
         pcTitle = title,
         pcContents = pack contents,
+        pcRhsContents = Nothing,
         pcPageName = name,
         pcOptions = API.defaultPageOpts
     }
@@ -114,6 +117,7 @@ editPageFromFile page comment fp = do
     contents <- liftIO $ readFile fp
     editPage page API.PageUpdate{
         puContents = Just $ pack contents,
+        puRhsContents = Nothing,
         puOptions = API.defaultPageOpts { API.poEditComment = Just comment }
     }
 
@@ -135,7 +139,11 @@ changeDeleteStatus :: Bool -> Text -> Warwick ()
 changeDeleteStatus deleted page = do
     authData <- getAuthData
     lift $ lift $ API.editPage authData (Just page) (Just "single") $ 
-        API.PageUpdate Nothing $ API.defaultPageOpts { API.poDeleted = Just deleted }
+        API.PageUpdate{
+            puContents = Nothing,
+            puRhsContents = Nothing,
+            puOptions = API.defaultPageOpts{ API.poDeleted = Just deleted }
+        }
 
 -- | 'deletePage' @path@ sets the deleted status to true for the page at @path@
 deletePage :: Text -> Warwick ()

--- a/src/Warwick/Sitebuilder/PageUpdate.hs
+++ b/src/Warwick/Sitebuilder/PageUpdate.hs
@@ -1,18 +1,21 @@
---------------------------------------------------------------------------------
--- Haskell bindings for the University of Warwick APIs                        --
--- Copyright 2019 Michael B. Gale (m.gale@warwick.ac.uk)                      --
---------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
+-- Haskell bindings for the University of Warwick APIs                       --
+-------------------------------------------------------------------------------
+-- This source code is licensed under the MIT licence found in the           --
+-- LICENSE file in the root directory of this source tree.                   --
+-------------------------------------------------------------------------------
 
 module Warwick.Sitebuilder.PageUpdate where 
 
 --------------------------------------------------------------------------------
 
+import Data.Default
 import Data.Text (Text)
 import Data.XML.Types 
 
 import Text.Atom.Feed
 import Text.Atom.Feed.Export
-import Text.XML
+import Text.XML (renderLBS)
 
 import Servant.API
 
@@ -22,9 +25,15 @@ import Warwick.Sitebuilder.PageOptions
 --------------------------------------------------------------------------------
 
 data PageUpdate = PageUpdate {
+    -- | The HTML to update the main page content with or `Nothing` to keep
+    -- the existing content.
     puContents :: Maybe Text,
+    -- | The HTML to update the RHS page content with or `Nothing` to keep the
+    -- existing content.
+    puRhsContents :: Maybe Text,
+    -- | Other page options to change.
     puOptions :: PageOptions
-} deriving Show
+} deriving (Eq, Show)
 
 instance MimeRender ATOM PageUpdate where 
     mimeRender _ PageUpdate{..} = 
@@ -38,7 +47,13 @@ instance MimeRender ATOM PageUpdate where
                     ContentText "http://go.warwick.ac.uk/elab-schemas/atom"
                 ])
             ],
-            entryOther = optsToXML puOptions
+            entryOther = 
+                let other = optsToXML puOptions
+                    rhsElement = puRhsContents >>= \rhsContent -> pure $
+                        (xmlContent $ HTMLContent rhsContent){
+                            elementName = "sitebuilder:rhs-content"
+                        } 
+                in maybe other (: other) rhsElement 
         } 
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
This PR adds support for creating/updating pages with RHS content. This is blocked on:
- Monday's Sitebuilder release which adds support for updating RHS content via the API https://github.com/UniversityofWarwick/sitebuilder/commit/31c35a75cff7e66fd37ef20ddb1cbe040ab44e15
- Adding support for creating pages with RHS content via the API, which I believe @oscar-h64 is working on

Other outstanding tasks:
- [x] Update documentation to document `rhsContent` field 
- [x] Bump version number